### PR TITLE
fix(config): binding of TMUXAI_OPENROUTER_API_KEY variable

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -72,6 +72,6 @@ func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "Print version information")
 }
 
-func Execute(cfg *config.Config) error {
+func Execute() error {
 	return rootCmd.Execute()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,7 @@ func Load() (*Config, error) {
 	// Environment variables
 	viper.SetEnvPrefix("TMUXAI")
 	viper.AutomaticEnv()
+	viper.BindEnv("openrouter.api_key", "TMUXAI_OPENROUTER_API_KEY")
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/alvinunreal/tmuxai/cli"
-	"github.com/alvinunreal/tmuxai/config"
 	"github.com/alvinunreal/tmuxai/logger"
 )
 
@@ -17,17 +16,8 @@ func main() {
 	}
 	logger.Info("TmuxAI starting up")
 
-	// Initialize configuration
-	cfg, err := config.Load()
-	if err != nil {
-		logger.Error("Error loading configuration: %v", err)
-		fmt.Fprintf(os.Stderr, "Error loading configuration: %v\n", err)
-		os.Exit(1)
-	}
-	logger.Info("Configuration loaded successfully")
-
 	// Start the CLI
-	if err := cli.Execute(cfg); err != nil {
+	if err := cli.Execute(); err != nil {
 		logger.Error("Error executing command: %v", err)
 		fmt.Fprintf(os.Stderr, "Error executing command: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
For some reason the binding doesn't work correctly for `TMUXAI_OPENROUTER_API_KEY`.
I haven't investigated too long, could be because there is no default value defined or something else.
Forcing the binding of the key to the env variable using `BindEnv()` does fix the issue.

While troubleshooting I noticed the `config.Load()` was called twice, so I took the opportunity to remove this redundant call which is already triggered in `cli.Execute()`.

Close https://github.com/alvinunreal/tmuxai/issues/5