### PR TITLE
Modify .goreleaser.yml to mark tmux as a dependency for the homebrew release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,6 +92,8 @@ brews:
       name: alvinunreal
       email: alvin@tmuxai.dev
     directory: Formula
+    dependencies:
+      - name: tmux
     homepage: https://tmuxai.dev/
     description: AI-Powered, Non-Intrusive Terminal Assistant
     test: |


### PR DESCRIPTION
Noticed that my homebrew install did not work out-of-the-box. I did not have tmux installed. This was a silent failure. I found the error in the ~/.config/tmuxai/tmuxai.log:
`
2025/05/01 15:10:57 [ERROR] manager.NewManager failed: system.TmuxCreateSession failed: exec: "tmux": executable file not found in $PATH`