### PR TITLE
Add AI provider selection and Pollinations.ai integration

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -70,6 +70,8 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVarP(&taskFileFlag, "file", "f", "", "Read request from specified file")
 	rootCmd.Flags().BoolP("version", "v", false, "Print version information")
+	// Add flag to select AI provider
+	rootCmd.Flags().String("ai-provider", "openrouter", "Select AI provider (openrouter, pollinations_ai)")
 }
 
 func Execute() error {

--- a/config/config.go
+++ b/config/config.go
@@ -12,17 +12,18 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	Debug                 bool             `mapstructure:"debug"`
-	MaxCaptureLines       int              `mapstructure:"max_capture_lines"`
-	MaxContextSize        int              `mapstructure:"max_context_size"`
-	WaitInterval          int              `mapstructure:"wait_interval"`
-	SendKeysConfirm       bool             `mapstructure:"send_keys_confirm"`
-	PasteMultilineConfirm bool             `mapstructure:"paste_multiline_confirm"`
-	ExecConfirm           bool             `mapstructure:"exec_confirm"`
-	WhitelistPatterns     []string         `mapstructure:"whitelist_patterns"`
-	BlacklistPatterns     []string         `mapstructure:"blacklist_patterns"`
-	OpenRouter            OpenRouterConfig `mapstructure:"openrouter"`
-	Prompts               PromptsConfig    `mapstructure:"prompts"`
+	Debug                 bool                 `mapstructure:"debug"`
+	MaxCaptureLines       int                  `mapstructure:"max_capture_lines"`
+	MaxContextSize        int                  `mapstructure:"max_context_size"`
+	WaitInterval          int                  `mapstructure:"wait_interval"`
+	SendKeysConfirm       bool                 `mapstructure:"send_keys_confirm"`
+	PasteMultilineConfirm bool                 `mapstructure:"paste_multiline_confirm"`
+	ExecConfirm           bool                 `mapstructure:"exec_confirm"`
+	WhitelistPatterns     []string             `mapstructure:"whitelist_patterns"`
+	BlacklistPatterns     []string             `mapstructure:"blacklist_patterns"`
+	OpenRouter            OpenRouterConfig     `mapstructure:"openrouter"`
+	Prompts               PromptsConfig        `mapstructure:"prompts"`
+	PollinationsAI        PollinationsAIConfig `mapstructure:"pollinations_ai"`
 }
 
 // OpenRouterConfig holds OpenRouter API configuration
@@ -38,6 +39,11 @@ type PromptsConfig struct {
 	ChatAssistant         string `mapstructure:"chat_assistant"`
 	ChatAssistantPrepared string `mapstructure:"chat_assistant_prepared"`
 	Watch                 string `mapstructure:"watch"`
+}
+
+// PollinationsAIConfig holds Pollinations.ai API configuration
+type PollinationsAIConfig struct {
+	APIKey string `mapstructure:"api_key"`
 }
 
 // DefaultConfig returns a configuration with default values

--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,9 @@ type PromptsConfig struct {
 }
 
 // PollinationsAIConfig holds Pollinations.ai API configuration
-type PollinationsAIConfig struct {
-	APIKey string `mapstructure:"api_key"`
-}
+// Da keine API Keys benötigt werden, ist die Struktur leer
+// (früher: APIKey string `mapstructure:"api_key"`)
+type PollinationsAIConfig struct{}
 
 // DefaultConfig returns a configuration with default values
 func DefaultConfig() *Config {
@@ -66,6 +66,7 @@ func DefaultConfig() *Config {
 			BaseSystem:    ``,
 			ChatAssistant: ``,
 		},
+		PollinationsAI: PollinationsAIConfig{},
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for a new AI provider, Pollinations.ai, alongside the existing OpenRouter integration. The changes include updates to the CLI, configuration handling, and the addition of a new client for interacting with the Pollinations.ai API.

### CLI Enhancements:
* Added a new flag `--ai-provider` to the CLI, allowing users to select between "openrouter" and "pollinations_ai" as the AI provider.

### Configuration Updates:
* Added a new `PollinationsAIConfig` struct to hold Pollinations.ai-specific API configuration, and updated the `Config` struct to include it. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R26) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R44-R48)

### Pollinations.ai Client Implementation:
* Introduced a new `PollinationsAIClient` struct and associated methods for interacting with the Pollinations.ai API, including a `ChatCompletion` method to send chat completion requests.