### PR TITLE
Add Azure OpenAI Endpoint support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ export TMUXAI_DEBUG=true
 export TMUXAI_MAX_CAPTURE_LINES=300
 export TMUXAI_OPENROUTER_API_KEY="your-api-key-here"
 export TMUXAI_OPENROUTER_MODEL="..."
+export TMUXAI_AZURE_OPENAI_API_KEY="your-azure-api-key"
+export TMUXAI_AZURE_OPENAI_API_BASE="https://your-resource.openai.azure.com/"
+export TMUXAI_AZURE_OPENAI_API_VERSION="2025-04-01-preview"
+export TMUXAI_AZURE_OPENAI_DEPLOYMENT_NAME="gpt-4o"
 ```
 
 You can also use environment variables directly within your configuration file values. The application will automatically expand these variables when loading the configuration:
@@ -391,6 +395,16 @@ openrouter:
   api_key: api-key
   model: gemma3:1b
   base_url: http://localhost:11434/v1
+```
+
+For Azure OpenAI:
+
+```yaml
+azure_openai:
+  api_key: "your-azure-openai-key"
+  api_base: "https://your-resource.openai.azure.com/"
+  api_version: "2025-04-01-preview"
+  deployment_name: "gpt-4o"
 ```
 
 _Prompts are currently tuned for Gemini 2.5 by default; behavior with other models may vary._

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,13 @@ openrouter:
   model: google/gemini-2.5-flash-preview # default model
   base_url: https://openrouter.ai/api/v1 # default base url
 
+# Azure OpenAI configuration
+# azure_openai:
+#   api_key: <your-azure-openai-api-key>
+#   api_base: https://your-resource.openai.azure.com/
+#   api_version: 2025-04-01-preview
+#   deployment_name: gpt-4o
+
 # OpenAI example
 # openrouter:
 #   api_key: sk-XXXXXXXXX

--- a/config/config.go
+++ b/config/config.go
@@ -12,17 +12,18 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	Debug                 bool             `mapstructure:"debug"`
-	MaxCaptureLines       int              `mapstructure:"max_capture_lines"`
-	MaxContextSize        int              `mapstructure:"max_context_size"`
-	WaitInterval          int              `mapstructure:"wait_interval"`
-	SendKeysConfirm       bool             `mapstructure:"send_keys_confirm"`
-	PasteMultilineConfirm bool             `mapstructure:"paste_multiline_confirm"`
-	ExecConfirm           bool             `mapstructure:"exec_confirm"`
-	WhitelistPatterns     []string         `mapstructure:"whitelist_patterns"`
-	BlacklistPatterns     []string         `mapstructure:"blacklist_patterns"`
-	OpenRouter            OpenRouterConfig `mapstructure:"openrouter"`
-	Prompts               PromptsConfig    `mapstructure:"prompts"`
+	Debug                 bool              `mapstructure:"debug"`
+	MaxCaptureLines       int               `mapstructure:"max_capture_lines"`
+	MaxContextSize        int               `mapstructure:"max_context_size"`
+	WaitInterval          int               `mapstructure:"wait_interval"`
+	SendKeysConfirm       bool              `mapstructure:"send_keys_confirm"`
+	PasteMultilineConfirm bool              `mapstructure:"paste_multiline_confirm"`
+	ExecConfirm           bool              `mapstructure:"exec_confirm"`
+	WhitelistPatterns     []string          `mapstructure:"whitelist_patterns"`
+	BlacklistPatterns     []string          `mapstructure:"blacklist_patterns"`
+	OpenRouter            OpenRouterConfig  `mapstructure:"openrouter"`
+	AzureOpenAI           AzureOpenAIConfig `mapstructure:"azure_openai"`
+	Prompts               PromptsConfig     `mapstructure:"prompts"`
 }
 
 // OpenRouterConfig holds OpenRouter API configuration
@@ -30,6 +31,14 @@ type OpenRouterConfig struct {
 	APIKey  string `mapstructure:"api_key"`
 	Model   string `mapstructure:"model"`
 	BaseURL string `mapstructure:"base_url"`
+}
+
+// AzureOpenAIConfig holds Azure OpenAI API configuration
+type AzureOpenAIConfig struct {
+	APIKey         string `mapstructure:"api_key"`
+	APIBase        string `mapstructure:"api_base"`
+	APIVersion     string `mapstructure:"api_version"`
+	DeploymentName string `mapstructure:"deployment_name"`
 }
 
 // PromptsConfig holds customizable prompt templates
@@ -56,6 +65,7 @@ func DefaultConfig() *Config {
 			BaseURL: "https://openrouter.ai/api/v1",
 			Model:   "google/gemini-2.5-flash-preview",
 		},
+		AzureOpenAI: AzureOpenAIConfig{},
 		Prompts: PromptsConfig{
 			BaseSystem:    ``,
 			ChatAssistant: ``,

--- a/internal/ai_client_test.go
+++ b/internal/ai_client_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alvinunreal/tmuxai/config"
+)
+
+func TestAzureOpenAIEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openai/deployments/test-dep/chat/completions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("api-version") != "2025-04-01-preview" {
+			t.Errorf("missing api-version query")
+		}
+		if r.Header.Get("api-key") != "test-key" {
+			t.Errorf("missing api-key header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		OpenRouter: config.OpenRouterConfig{},
+		AzureOpenAI: config.AzureOpenAIConfig{
+			APIKey:         "test-key",
+			APIBase:        server.URL,
+			APIVersion:     "2025-04-01-preview",
+			DeploymentName: "test-dep",
+		},
+	}
+
+	client := NewAiClient(cfg)
+	msg := []Message{{Role: "user", Content: "hi"}}
+	resp, err := client.ChatCompletion(context.Background(), msg, "model")
+	if err != nil {
+		t.Fatalf("ChatCompletion error: %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("unexpected response: %s", resp)
+	}
+}

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -46,9 +46,9 @@ type Manager struct {
 
 // NewManager creates a new manager agent
 func NewManager(cfg *config.Config) (*Manager, error) {
-	if cfg.OpenRouter.APIKey == "" {
-		fmt.Println("OpenRouter API key is required. Set it in the config file or as an environment variable: TMUXAI_OPENROUTER_API_KEY")
-		return nil, fmt.Errorf("OpenRouter API key is required")
+	if cfg.OpenRouter.APIKey == "" && cfg.AzureOpenAI.APIKey == "" {
+		fmt.Println("An API key is required. Set OpenRouter or Azure OpenAI credentials in the config file or environment variables.")
+		return nil, fmt.Errorf("API key required")
 	}
 
 	paneId, err := system.TmuxCurrentPaneId()
@@ -71,7 +71,7 @@ func NewManager(cfg *config.Config) (*Manager, error) {
 		os.Exit(0)
 	}
 
-	aiClient := NewAiClient(&cfg.OpenRouter)
+	aiClient := NewAiClient(cfg)
 	os := system.GetOSDetails()
 
 	manager := &Manager{


### PR DESCRIPTION
Problem: Azure OpenAI Service offers an OpenAI compatible API but with a slight twist, that requires adding the api version as a query parameter, not possible in today’s implementation.

This PR aims to address that and adds Azure OpenAI endpoint/config support:

- adds Azure OpenAI config section and defaults
- detects Azure OpenAI in AiClient and build correct endpoint and headers
- updates Manager to allow either OpenRouter or Azure creds
- documents Azure OpenAI usage and environment variables
- includes sample Azure OpenAI config
- tests Azure endpoint construction and auth header