### PR TITLE
Increase default context size from 20k to 100k tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ Context
 ────────
 
 Messages            15
-Context Size~       16500 tokens
+Context Size~       82500 tokens
                     ████████░░ 82.5%
-Max Size            20000 tokens
+Max Size            100000 tokens
 ```
 
-This example shows that the context is at 82.5% capacity (16,500 tokens out of 20,000). When the context size reaches 80% of the configured maximum (`max_context_size` in your config), TmuxAI automatically triggers squashing.
+This example shows that the context is at 82.5% capacity (82,500 tokens out of 100,000). When the context size reaches 80% of the configured maximum (`max_context_size` in your config), TmuxAI automatically triggers squashing.
 
 ### Manual Squashing
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,4 @@
-max_context_size: 20000 # Maximum context size in tokens, reaching 80% triggers squashing
+max_context_size: 100000 # Maximum context size in tokens, reaching 80% triggers squashing
 max_capture_lines: 200 # Maximum number of lines to capture during each message
 wait_interval: 5 # Wait interval when exec pane is considered busy (used in observe and watch modes)
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Debug:                 false,
 		MaxCaptureLines:       200,
-		MaxContextSize:        20000,
+		MaxContextSize:        100000,
 		WaitInterval:          5,
 		SendKeysConfirm:       true,
 		PasteMultilineConfirm: true,


### PR DESCRIPTION
- Update DefaultConfig() in config/config.go: 20000 -> 100000
- Update config.example.yaml: 20000 -> 100000
- Update README.md example: 16500/20000 -> 82500/100000

Fixes #63 - 20k context size was too small and caused frequent squashing that disrupted conversation flow. 100k provides 5x more capacity while staying within modern AI model limits.

🤖 Generated with [Claude Code](https://claude.ai/code)