### PR TITLE
Add GitHub Copilot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,39 @@ azure_openai:
   deployment_name: "gpt-4o"
 ```
 
+For GitHub Copilot:
+
+```yaml
+github_copilot:
+  token: "ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  model: "gpt-4o"
+  base_url: "https://api.github.com"
+```
+
+#### Setting up GitHub Copilot
+
+To use GitHub Copilot with TmuxAI, you'll need:
+
+1. **A GitHub Copilot subscription** - GitHub Copilot requires an active subscription
+2. **A GitHub Personal Access Token** with the appropriate scopes:
+   - Go to GitHub Settings > Developer settings > Personal access tokens
+   - Create a new token with the `copilot` scope (or `read:user` for basic access)
+3. **Configure the token** in your TmuxAI configuration:
+
+```bash
+export TMUXAI_GITHUB_COPILOT_TOKEN="ghp_your_token_here"
+```
+
+Or add it to your `~/.config/tmuxai/config.yaml`:
+
+```yaml
+github_copilot:
+  token: "ghp_your_token_here"
+  model: "gpt-4o"
+```
+
+Available models for GitHub Copilot include `gpt-4o`, `gpt-4`, and `gpt-3.5-turbo`. The model selection will depend on your Copilot subscription tier.
+
 _Prompts are currently tuned for Gemini 2.5 by default; behavior with other models may vary._
 
 ## Contributing

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,12 @@ openrouter:
 #   api_version: 2025-04-01-preview
 #   deployment_name: gpt-4o
 
+# GitHub Copilot configuration
+# github_copilot:
+#   token: ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+#   model: gpt-4o # available models: gpt-4o, gpt-4, gpt-3.5-turbo
+#   base_url: https://api.github.com # default GitHub API endpoint
+
 # OpenAI example
 # openrouter:
 #   api_key: sk-XXXXXXXXX

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	BlacklistPatterns     []string          `mapstructure:"blacklist_patterns"`
 	OpenRouter            OpenRouterConfig  `mapstructure:"openrouter"`
 	AzureOpenAI           AzureOpenAIConfig `mapstructure:"azure_openai"`
+	GitHubCopilot         GitHubCopilotConfig `mapstructure:"github_copilot"`
 	Prompts               PromptsConfig     `mapstructure:"prompts"`
 }
 
@@ -39,6 +40,13 @@ type AzureOpenAIConfig struct {
 	APIBase        string `mapstructure:"api_base"`
 	APIVersion     string `mapstructure:"api_version"`
 	DeploymentName string `mapstructure:"deployment_name"`
+}
+
+// GitHubCopilotConfig holds GitHub Copilot API configuration
+type GitHubCopilotConfig struct {
+	Token   string `mapstructure:"token"`
+	Model   string `mapstructure:"model"`
+	BaseURL string `mapstructure:"base_url"`
 }
 
 // PromptsConfig holds customizable prompt templates
@@ -66,6 +74,10 @@ func DefaultConfig() *Config {
 			Model:   "google/gemini-2.5-flash-preview",
 		},
 		AzureOpenAI: AzureOpenAIConfig{},
+		GitHubCopilot: GitHubCopilotConfig{
+			BaseURL: "https://api.github.com",
+			Model:   "gpt-4o",
+		},
 		Prompts: PromptsConfig{
 			BaseSystem:    ``,
 			ChatAssistant: ``,

--- a/internal/ai_client.go
+++ b/internal/ai_client.go
@@ -111,6 +111,12 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 
 		// Azure endpoint doesn't expect model in body
 		reqBody.Model = ""
+	} else if c.config.GitHubCopilot.Token != "" {
+		// Use GitHub Copilot endpoint
+		baseURL := strings.TrimSuffix(c.config.GitHubCopilot.BaseURL, "/")
+		url = baseURL + "/copilot/chat/completions"
+		apiKeyHeader = "Authorization"
+		apiKey = "Bearer " + c.config.GitHubCopilot.Token
 	} else {
 		// default OpenRouter/OpenAI compatible endpoint
 		baseURL := strings.TrimSuffix(c.config.OpenRouter.BaseURL, "/")
@@ -134,6 +140,13 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(apiKeyHeader, apiKey)
+
+	// GitHub Copilot specific headers
+	if c.config.GitHubCopilot.Token != "" {
+		req.Header.Set("Copilot-Integration-Id", "tmuxai")
+		req.Header.Set("Copilot-Integration-Version", "1.0.0")
+		req.Header.Set("User-Agent", "TmuxAI/1.0.0")
+	}
 
 	req.Header.Set("HTTP-Referer", "https://github.com/alvinunreal/tmuxai")
 	req.Header.Set("X-Title", "TmuxAI")

--- a/internal/config_helpers.go
+++ b/internal/config_helpers.go
@@ -75,6 +75,27 @@ func (m *Manager) GetExecConfirm() bool {
 }
 
 func (m *Manager) GetOpenRouterModel() string {
+	return m.GetAIModel()
+}
+
+func (m *Manager) GetAIModel() string {
+	// Check for GitHub Copilot configuration first
+	if m.Config.GitHubCopilot.Token != "" {
+		if override, exists := m.SessionOverrides["github_copilot.model"]; exists {
+			if val, ok := override.(string); ok {
+				return val
+			}
+		}
+		return m.Config.GitHubCopilot.Model
+	}
+	
+	// Check for Azure OpenAI configuration
+	if m.Config.AzureOpenAI.APIKey != "" {
+		// Azure uses deployment name instead of model
+		return m.Config.AzureOpenAI.DeploymentName
+	}
+	
+	// Default to OpenRouter model
 	if override, exists := m.SessionOverrides["openrouter.model"]; exists {
 		if val, ok := override.(string); ok {
 			return val


### PR DESCRIPTION
- Add GitHubCopilotConfig struct with token, model, and base_url fields
- Update AI client to support GitHub Copilot API endpoint
- Implement Copilot-specific headers and authentication
- Add GetAIModel() method to handle provider-specific model selection
- Update configuration example with GitHub Copilot settings
- Add comprehensive documentation for GitHub Copilot setup

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)