### PR TITLE
feat: add model profiles with CLI flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ TmuxAI » /squash
 | `/reset`                    | Clear chat history and reset all panes.                          |
 | `/config`                   | View current configuration settings                              |
 | `/config set <key> <value>` | Override configuration for current session                       |
+| `/model list`               | List all available model profiles                                |
+| `/model use <name>`         | Switch to a specific model profile                               |
+| `/model current`            | Show currently active model information                          |
 | `/squash`                   | Manually trigger context summarization                           |
 | `/prepare [shell]`          | Initialize Prepared Mode for the Exec Pane (e.g., bash, zsh)     |
 | `/watch <description>`      | Enable Watch Mode with specified goal                            |
@@ -330,7 +333,7 @@ TmuxAI » /squash
 
 ## Command-Line Usage
 
-You can start `tmuxai` with an initial message or task file from the command line:
+You can start `tmuxai` with an initial message, task file, or specific model from the command line:
 
 - **Direct Message:**
 
@@ -341,6 +344,18 @@ You can start `tmuxai` with an initial message or task file from the command lin
 - **Task File:**
   ```sh
   tmuxai -f path/to/your_task.txt
+  ```
+
+- **Select Model:**
+  ```sh
+  tmuxai -m fast
+  # or
+  tmuxai --model powerful
+  ```
+
+- **Combined Options:**
+  ```sh
+  tmuxai -m local -f task.txt
   ```
 
 ## Configuration
@@ -406,6 +421,78 @@ TmuxAI » /config set openrouter.model gpt-4o-mini
 ```
 
 These changes will persist only for the current session and won't modify your config file.
+
+### Model Profiles
+
+Model profiles allow you to define multiple AI model configurations and easily switch between them during sessions. This is useful for:
+
+- Switching between fast/cheap models for simple tasks and powerful models for complex ones
+- Testing different models without editing config files
+- Managing separate profiles for local development, cloud APIs, etc.
+
+#### Configuration
+
+Define model profiles in your config file using the `models` key:
+
+```yaml
+# Optional: Set default model to use at startup
+default_model: fast
+
+# Define named model profiles
+models:
+  fast:
+    provider: openrouter
+    model: google/gemini-2.5-flash-preview
+    api_key: "${OPENROUTER_KEY}"
+    base_url: https://openrouter.ai/api/v1
+
+  powerful:
+    provider: openai
+    model: gpt-5-codex
+    api_key: "${OPENAI_KEY}"
+
+  local:
+    provider: openrouter
+    model: gemma3:1b
+    api_key: ollama
+    base_url: http://localhost:11434/v1
+
+  azure-prod:
+    provider: azure
+    api_key: "${AZURE_KEY}"
+    api_base: https://your-resource.openai.azure.com
+    api_version: "2024-02-01"
+    deployment_name: gpt-4o
+```
+
+#### Using Model Profiles
+
+**In Session Commands:**
+
+```bash
+# List all available models
+TmuxAI » /model list
+
+# Switch to a specific model
+TmuxAI » /model use powerful
+
+# Show current model details
+TmuxAI » /model current
+```
+
+**CLI Flag:**
+
+```bash
+# Start with a specific model
+tmuxai -m fast
+
+# Or use the long form
+tmuxai --model powerful
+```
+
+#### Backward Compatibility
+
+Model profiles are completely optional. If you don't define any profiles, TmuxAI will continue to work with the traditional OpenAI/Azure/OpenRouter direct configuration (see below).
 
 ### Using Other AI Providers
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,6 +16,7 @@ import (
 var (
 	initMessage  string
 	taskFileFlag string
+	modelFlag    string
 )
 
 var rootCmd = &cobra.Command{
@@ -56,6 +57,17 @@ var rootCmd = &cobra.Command{
 			logger.Error("manager.NewManager failed: %v", err)
 			os.Exit(1)
 		}
+
+		// Set active model from CLI flag if provided
+		if modelFlag != "" {
+			if err := mgr.SetActiveModel(modelFlag); err != nil {
+				logger.Error("Failed to set model: %v", err)
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			logger.Info("Using model from CLI flag: %s", modelFlag)
+		}
+
 		if initMessage != "" {
 			logger.Info("Starting with initial subcommand: %s", initMessage)
 		}
@@ -69,6 +81,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.Flags().StringVarP(&taskFileFlag, "file", "f", "", "Read request from specified file")
+	rootCmd.Flags().StringVarP(&modelFlag, "model", "m", "", "Select model profile to use")
 	rootCmd.Flags().BoolP("version", "v", false, "Print version information")
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,36 @@ send_keys_confirm: true # Confirm before executing send keys
 paste_multiline_confirm: true # Confirm before pasting multiline content
 exec_confirm: true # Confirm before executing commands
 
+# Model Profiles - Define multiple model configurations and switch between them
+# Use /model list, /model use <name>, /model current commands or --model CLI flag
+# default_model: fast  # Optional: Set default model to use at startup
+
+# models:
+#   fast:
+#     provider: openrouter
+#     model: google/gemini-2.5-flash-preview
+#     api_key: "${OPENROUTER_KEY}"
+#     base_url: https://openrouter.ai/api/v1
+#
+#   powerful:
+#     provider: openai
+#     model: gpt-5-codex
+#     api_key: "${OPENAI_KEY}"
+#
+#   local:
+#     provider: openrouter
+#     model: gemma3:1b
+#     api_key: ollama
+#     base_url: http://localhost:11434/v1
+#
+#   azure-prod:
+#     provider: azure
+#     api_key: "${AZURE_KEY}"
+#     api_base: https://your-resource.openai.azure.com
+#     api_version: "2024-02-01"
+#     deployment_name: gpt-4o
+
+# Traditional configuration (still supported for backward compatibility)
 # OpenAI Responses API (recommended for new models like GPT-5)
 # openai:
 #   api_key: sk-XXXXXXXXX

--- a/internal/model_test.go
+++ b/internal/model_test.go
@@ -1,0 +1,256 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/alvinunreal/tmuxai/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test setting and retrieving active model
+func TestSetActiveModel(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"fast": {
+				Provider: "openrouter",
+				Model:    "google/gemini-2.5-flash-preview",
+				APIKey:   "test-key",
+				BaseURL:  "https://openrouter.ai/api/v1",
+			},
+			"powerful": {
+				Provider: "openai",
+				Model:    "gpt-5-codex",
+				APIKey:   "test-openai-key",
+			},
+		},
+		DefaultModel: "fast",
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		AiClient:         NewAiClient(cfg),
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      cfg.DefaultModel,
+	}
+
+	// Test setting to a valid model
+	err := manager.SetActiveModel("powerful")
+	assert.NoError(t, err)
+	assert.Equal(t, "powerful", manager.ActiveModel)
+
+	// Verify session overrides were set
+	assert.Equal(t, "test-openai-key", manager.SessionOverrides["openai.api_key"])
+	assert.Equal(t, "gpt-5-codex", manager.SessionOverrides["openai.model"])
+
+	// Test setting to an invalid model
+	err = manager.SetActiveModel("nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// Test listing models
+func TestListModels(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"fast": {
+				Provider: "openrouter",
+				Model:    "google/gemini-2.5-flash-preview",
+			},
+			"powerful": {
+				Provider: "openai",
+				Model:    "gpt-5-codex",
+			},
+			"local": {
+				Provider: "openrouter",
+				Model:    "gemma3:1b",
+			},
+		},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		SessionOverrides: make(map[string]interface{}),
+	}
+
+	models := manager.ListModels()
+	assert.Len(t, models, 3)
+	assert.Contains(t, models, "fast")
+	assert.Contains(t, models, "powerful")
+	assert.Contains(t, models, "local")
+}
+
+// Test GetActiveModelInfo with active model
+func TestGetActiveModelInfo_WithActiveModel(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"fast": {
+				Provider: "openrouter",
+				Model:    "google/gemini-2.5-flash-preview",
+				APIKey:   "test-key",
+				BaseURL:  "https://openrouter.ai/api/v1",
+			},
+		},
+		DefaultModel: "fast",
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "fast",
+	}
+
+	info := manager.GetActiveModelInfo()
+	assert.Contains(t, info, "Active Model: fast")
+	assert.Contains(t, info, "Provider: openrouter")
+	assert.Contains(t, info, "Model: google/gemini-2.5-flash-preview")
+	assert.Contains(t, info, "Base URL: https://openrouter.ai/api/v1")
+}
+
+// Test GetActiveModelInfo without active model (fallback to direct config)
+func TestGetActiveModelInfo_WithoutActiveModel(t *testing.T) {
+	cfg := &config.Config{
+		OpenRouter: config.OpenRouterConfig{
+			APIKey: "test-key",
+			Model:  "google/gemini-2.5-flash-preview",
+		},
+		Models: map[string]*config.ModelConfig{},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "",
+	}
+
+	info := manager.GetActiveModelInfo()
+	assert.Contains(t, info, "Provider: OpenRouter")
+	assert.Contains(t, info, "Model: google/gemini-2.5-flash-preview")
+	assert.Contains(t, info, "Using direct configuration")
+}
+
+// Test UpdateAiClientForModel with OpenRouter provider
+func TestUpdateAiClientForModel_OpenRouter(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"test": {
+				Provider: "openrouter",
+				Model:    "test-model",
+				APIKey:   "test-key",
+				BaseURL:  "https://test.example.com",
+			},
+		},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		AiClient:         NewAiClient(cfg),
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "test",
+	}
+
+	err := manager.UpdateAiClientForModel()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-key", manager.SessionOverrides["openrouter.api_key"])
+	assert.Equal(t, "test-model", manager.SessionOverrides["openrouter.model"])
+	assert.Equal(t, "https://test.example.com", manager.SessionOverrides["openrouter.base_url"])
+}
+
+// Test UpdateAiClientForModel with Azure provider
+func TestUpdateAiClientForModel_Azure(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"azure-test": {
+				Provider:       "azure",
+				APIKey:         "azure-key",
+				APIBase:        "https://test.openai.azure.com",
+				APIVersion:     "2024-02-01",
+				DeploymentName: "gpt-4o",
+			},
+		},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		AiClient:         NewAiClient(cfg),
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "azure-test",
+	}
+
+	err := manager.UpdateAiClientForModel()
+	assert.NoError(t, err)
+	assert.Equal(t, "azure-key", manager.SessionOverrides["azure_openai.api_key"])
+	assert.Equal(t, "https://test.openai.azure.com", manager.SessionOverrides["azure_openai.api_base"])
+	assert.Equal(t, "2024-02-01", manager.SessionOverrides["azure_openai.api_version"])
+	assert.Equal(t, "gpt-4o", manager.SessionOverrides["azure_openai.deployment_name"])
+}
+
+// Test UpdateAiClientForModel with invalid provider
+func TestUpdateAiClientForModel_InvalidProvider(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"invalid": {
+				Provider: "unknown-provider",
+				Model:    "test-model",
+				APIKey:   "test-key",
+			},
+		},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		AiClient:         NewAiClient(cfg),
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "invalid",
+	}
+
+	err := manager.UpdateAiClientForModel()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown provider")
+}
+
+// Test environment variable expansion in model configs
+func TestModelConfig_EnvExpansion(t *testing.T) {
+	// Set test environment variable
+	t.Setenv("TEST_API_KEY", "expanded-key")
+
+	cfg := &config.Config{
+		Models: map[string]*config.ModelConfig{
+			"test": {
+				Provider: "openai",
+				Model:    "gpt-5-codex",
+				APIKey:   "${TEST_API_KEY}",
+			},
+		},
+	}
+
+	// Manually resolve env vars (this would normally happen in config.Load)
+	config.ResolveEnvKeyInConfig(cfg)
+
+	assert.Equal(t, "expanded-key", cfg.Models["test"].APIKey)
+}
+
+// Test backward compatibility - works without model profiles
+func TestBackwardCompatibility_NoModelProfiles(t *testing.T) {
+	cfg := &config.Config{
+		OpenRouter: config.OpenRouterConfig{
+			APIKey: "test-key",
+			Model:  "google/gemini-2.5-flash-preview",
+		},
+		Models: map[string]*config.ModelConfig{},
+	}
+
+	manager := &Manager{
+		Config:           cfg,
+		AiClient:         NewAiClient(cfg),
+		SessionOverrides: make(map[string]interface{}),
+		ActiveModel:      "",
+	}
+
+	// Should work without any active model
+	models := manager.ListModels()
+	assert.Len(t, models, 0)
+
+	// GetActiveModelInfo should show direct config
+	info := manager.GetActiveModelInfo()
+	assert.Contains(t, info, "Using direct configuration")
+}


### PR DESCRIPTION
- Add ModelConfig struct supporting OpenAI, OpenRouter, and Azure
- Add Models map and DefaultModel to Config
- Implement /model list, /model use, /model current commands
- Add --model/-m CLI flag for startup model selection
- Support environment variable expansion in model configs
- Full backward compatibility with existing configurations
- Comprehensive tests with 10 test functions
- Updated README and config.example.yaml documentation

Implements #88