### PR TITLE
feat(execution pane) - added "clean shell" to enable prepare mode when user has custom shell setup (issue #100)

### DIFF
--- a/internal/exec_pane_test.go
+++ b/internal/exec_pane_test.go
@@ -141,23 +141,27 @@ func TestPrepareExecPaneWithShell(t *testing.T) {
 
 	// Test bash shell preparation
 	manager.PrepareExecPaneWithShell("bash")
-	assert.Len(t, commandsSent, 2, "Should send 2 commands for bash")
-	assert.Contains(t, commandsSent[0], "PS1=", "Should set PS1 for bash")
-	assert.Equal(t, "C-l", commandsSent[1], "Should clear screen")
+	assert.Len(t, commandsSent, 3, "Should send 3 commands for bash")
+	assert.Equal(t, "unset PROMPT_COMMAND", commandsSent[0], "Should unset PROMPT_COMMAND for bash")
+	assert.Contains(t, commandsSent[1], "PS1=", "Should set PS1 for bash")
+	assert.Equal(t, "C-l", commandsSent[2], "Should clear screen")
 
 	// Reset and test zsh shell preparation
 	commandsSent = []string{}
 	manager.PrepareExecPaneWithShell("zsh")
-	assert.Len(t, commandsSent, 2, "Should send 2 commands for zsh")
-	assert.Contains(t, commandsSent[0], "PROMPT=", "Should set PROMPT for zsh")
-	assert.Equal(t, "C-l", commandsSent[1], "Should clear screen")
+	assert.Len(t, commandsSent, 4, "Should send 4 commands for zsh")
+	assert.Equal(t, "unset PROMPT_COMMAND", commandsSent[0], "Should unset PROMPT_COMMAND for zsh")
+	assert.Equal(t, "unset precmd_functions", commandsSent[1], "Should unset precmd_functions for zsh")
+	assert.Contains(t, commandsSent[2], "PROMPT=", "Should set PROMPT for zsh")
+	assert.Equal(t, "C-l", commandsSent[3], "Should clear screen")
 
 	// Reset and test fish shell preparation
 	commandsSent = []string{}
 	manager.PrepareExecPaneWithShell("fish")
-	assert.Len(t, commandsSent, 2, "Should send 2 commands for fish")
-	assert.Contains(t, commandsSent[0], "fish_prompt", "Should set fish_prompt for fish")
-	assert.Equal(t, "C-l", commandsSent[1], "Should clear screen")
+	assert.Len(t, commandsSent, 3, "Should send 3 commands for fish")
+	assert.Equal(t, "functions -e fish_prompt", commandsSent[0], "Should delete fish_prompt function")
+	assert.Contains(t, commandsSent[1], "function fish_prompt", "Should set fish_prompt for fish")
+	assert.Equal(t, "C-l", commandsSent[2], "Should clear screen")
 
 	// Reset and test unsupported shell
 	commandsSent = []string{}
@@ -222,7 +226,7 @@ func TestExecWaitCapture_SSHScenario(t *testing.T) {
 	// Mock system functions to simulate SSH environment
 	originalTmuxSend := system.TmuxSendCommandToPane
 	originalTmuxCapture := system.TmuxCapturePane
-	defer func() { 
+	defer func() {
 		system.TmuxSendCommandToPane = originalTmuxSend
 		system.TmuxCapturePane = originalTmuxCapture
 	}()
@@ -277,7 +281,7 @@ func TestExecWaitCapture_SuccessfulExecution(t *testing.T) {
 	// Mock system functions to simulate successful execution
 	originalTmuxSend := system.TmuxSendCommandToPane
 	originalTmuxCapture := system.TmuxCapturePane
-	defer func() { 
+	defer func() {
 		system.TmuxSendCommandToPane = originalTmuxSend
 		system.TmuxCapturePane = originalTmuxCapture
 	}()

--- a/system/tmux.go
+++ b/system/tmux.go
@@ -11,29 +11,9 @@ import (
 	"github.com/alvinunreal/tmuxai/logger"
 )
 
-// GetCleanShellCommand returns the command to start a shell with no profile/rc loaded
-func GetCleanShellCommand(shell string) string {
-	switch shell {
-	case "bash":
-		return "bash --noprofile --norc"
-	case "zsh":
-		return "zsh -f"
-	case "fish":
-		return "fish --no-config"
-	default:
-		return shell
-	}
-}
-
 // TmuxCreateNewPane creates a new horizontal split pane in the specified window and returns its ID
-// If shellCommand is provided, it will be executed in the new pane
-func TmuxCreateNewPane(target string, shellCommand ...string) (string, error) {
-	args := []string{"split-window", "-d", "-h", "-t", target, "-P", "-F", "#{pane_id}"}
-	if len(shellCommand) > 0 && shellCommand[0] != "" {
-		args = append(args, shellCommand[0])
-	}
-
-	cmd := exec.Command("tmux", args...)
+func TmuxCreateNewPane(target string) (string, error) {
+	cmd := exec.Command("tmux", "split-window", "-d", "-h", "-t", target, "-P", "-F", "#{pane_id}")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
Adds shell detection and relevant shell invocation args that ensure the execution pane is a "clear shell", so /prepare can hook in and add it's magic sauce. Fixes issue #100, where custom prompts caused /prepare to not work.

All codebase tests pass. Manually tested on my setup (bash, kitty, Arch, with custom starship prompt) and worked as expected - execution pane was a clean bash shell, /prepare was able to prepare. May need other testing on zsh/fish

Related issue #100