### PR TITLE
Add Synthetic provider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -52,6 +52,12 @@ models:
     api_version: "2025-04-01-preview"
     deployment_name: "gpt-4o"
 
+  synthetic-glm-4-6:
+    provider: "synthetic"
+    model: "hf:zai-org/GLM-4.6"
+    api_key: "your-synthetic-api-key"
+    base_url: "https://api.synthetic.new/openai/v1"
+
 # Confirm before AI executes a command
 exec_confirm: true
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	BlacklistPatterns     []string              `mapstructure:"blacklist_patterns"`
 	OpenRouter            OpenRouterConfig      `mapstructure:"openrouter"`
 	OpenAI                OpenAIConfig          `mapstructure:"openai"`
-	AzureOpenAI           AzureOpenAIConfig     `mapstructure:"azure_openai"`
+	AzureOpenAI           AzureOpenAIConfig     `mapstructure:"azure_open_ai"`
+	Synthetic             SyntheticConfig       `mapstructure:"synthetic"`
 	DefaultModel          string                 `mapstructure:"default_model"`
 	Models                map[string]ModelConfig  `mapstructure:"models"`
 	Prompts               PromptsConfig         `mapstructure:"prompts"`
@@ -50,6 +51,13 @@ type AzureOpenAIConfig struct {
 	APIBase        string `mapstructure:"api_base"`
 	APIVersion     string `mapstructure:"api_version"`
 	DeploymentName string `mapstructure:"deployment_name"`
+}
+
+// SyntheticConfig holds Synthetic API configuration
+type SyntheticConfig struct {
+	APIKey  string `mapstructure:"api_key"`
+	Model   string `mapstructure:"model"`
+	BaseURL string `mapstructure:"base_url"`
 }
 
 
@@ -100,6 +108,9 @@ func DefaultConfig() *Config {
 			BaseURL: "https://api.openai.com/v1",
 		},
 		AzureOpenAI: AzureOpenAIConfig{},
+		Synthetic: SyntheticConfig{
+			BaseURL: "https://api.synthetic.new/openai/v1",
+		},
 		DefaultModel: "",
 	Models:       make(map[string]ModelConfig),
 		Prompts: PromptsConfig{

--- a/internal/ai_client.go
+++ b/internal/ai_client.go
@@ -131,7 +131,7 @@ func (c *AiClient) determineAPIType(model string) string {
 				return "responses"
 			case "azure":
 				return "azure"
-			case "openrouter":
+			case "openrouter", "synthetic":
 				return "openrouter"
 			default:
 				return "openrouter"
@@ -148,6 +148,11 @@ func (c *AiClient) determineAPIType(model string) string {
 	// If Azure OpenAI is configured, use Azure Chat Completions
 	if c.config.AzureOpenAI.APIKey != "" {
 		return "azure"
+	}
+
+	// If Synthetic is configured, use OpenRouter-compatible Chat Completions
+	if c.config.Synthetic.APIKey != "" {
+		return "openrouter"
 	}
 
 	// Default to OpenRouter Chat Completions
@@ -239,6 +244,10 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 			apiBase = c.config.AzureOpenAI.APIBase
 			apiVersion = c.config.AzureOpenAI.APIVersion
 			deploymentName = c.config.AzureOpenAI.DeploymentName
+		} else if c.config.Synthetic.APIKey != "" {
+			provider = "synthetic"
+			apiKey = c.config.Synthetic.APIKey
+			baseURL = c.config.Synthetic.BaseURL
 		} else if c.config.OpenRouter.APIKey != "" {
 			provider = "openrouter"
 			apiKey = c.config.OpenRouter.APIKey


### PR DESCRIPTION
Adds basic support for [Synthetic](https://synthetic.new/). Works for me (tested with GLM 4.6).