### PR TITLE
Fix GitHub Copilot support by adding required headers

### DIFF
--- a/internal/ai_client.go
+++ b/internal/ai_client.go
@@ -299,6 +299,12 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 	req.Header.Set("HTTP-Referer", "https://github.com/alvinunreal/tmuxai")
 	req.Header.Set("X-Title", "TmuxAI")
 
+	// Add GitHub Copilot-specific headers when using Copilot API
+	if strings.Contains(url, "githubcopilot.com") {
+		req.Header.Set("editor-version", "tmuxai/"+Version)
+		req.Header.Set("copilot-integration-id", "vscode-chat")
+	}
+
 	// Log the request details for debugging before sending
 	logger.Debug("Sending API request to: %s with model: %s", url, model)
 


### PR DESCRIPTION
When trying to use the GitHub Copilot configuration from the README (#94), I was getting:

```
bad request: missing Editor-Version header for IDE auth
```

It looks like GitHub's Copilot API started requiring `editor-version` and `copilot-integration-id` headers at some point. Looking at other projects with working Copilot support that were referenced in #47:

- shell-ask added these headers: https://github.com/egoist/shell-ask/commit/2b7c78e8f2ddec509ed52ade168986ace01d7b55 (Nov 2024)
- gptel added these headers: https://github.com/karthink/gptel/commit/b60589fa24b9f3e0ad07b90ce5562e07d0ef1400 (Apr 2025)

This PR adds the same headers when the Copilot API is detected (via `githubcopilot.com` in the URL).

Tested and working.