### PR TITLE
feat: add --config flag and TMUXAI_CONFIG env var for custom config path

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,13 +14,14 @@ import (
 )
 
 var (
-	initMessage   string
-	taskFileFlag  string
-	kbFlag        string
-	modelFlag     string
-	execPaneFlag  string
-	readPanesFlag string
-	yoloFlag      bool
+	initMessage    string
+	taskFileFlag   string
+	kbFlag         string
+	modelFlag      string
+	execPaneFlag   string
+	readPanesFlag  string
+	yoloFlag       bool
+	configFileFlag string
 )
 
 var rootCmd = &cobra.Command{
@@ -34,7 +35,7 @@ var rootCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.Load()
+		cfg, err := config.Load(configFileFlag)
 		if err != nil {
 			logger.Error("Error loading configuration: %v", err)
 			fmt.Fprintf(os.Stderr, "Error loading configuration: %v\n", err)
@@ -111,6 +112,7 @@ func init() {
 	rootCmd.Flags().StringVar(&readPanesFlag, "read-panes", "", "Comma-separated tmux pane IDs to use as read context (e.g., --read-panes %1,%2)")
 	rootCmd.Flags().BoolVar(&yoloFlag, "yolo", false, "Skip all confirmation prompts and execute commands directly")
 	rootCmd.Flags().BoolP("version", "v", false, "Print version information")
+	rootCmd.Flags().StringVar(&configFileFlag, "config", "", "Path to config file (overrides default ~/.config/tmuxai/config.yaml, also settable via TMUXAI_CONFIG env var)")
 }
 
 func Execute() error {

--- a/config/config.go
+++ b/config/config.go
@@ -124,25 +124,34 @@ func DefaultConfig() *Config {
 	}
 }
 
-// Load loads the configuration from file or environment variables
-func Load() (*Config, error) {
+// Load loads the configuration from file or environment variables.
+// An optional configFilePath can be passed to load from a specific file.
+func Load(configFilePath ...string) (*Config, error) {
 	config := DefaultConfig()
 
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get user home directory: %w", err)
-	}
-
-	viper.AddConfigPath(".")
-
-	configDir, err := GetConfigDir()
-	if err == nil {
-		viper.AddConfigPath(configDir)
+	// If a custom config file path is provided, use it directly
+	if len(configFilePath) > 0 && configFilePath[0] != "" {
+		viper.SetConfigFile(configFilePath[0])
+	} else if envPath := os.Getenv("TMUXAI_CONFIG"); envPath != "" {
+		// Support TMUXAI_CONFIG env var as well
+		viper.SetConfigFile(envPath)
 	} else {
-		viper.AddConfigPath(filepath.Join(homeDir, ".config", "tmuxai"))
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get user home directory: %w", err)
+		}
+
+		viper.AddConfigPath(".")
+
+		configDir, err := GetConfigDir()
+		if err == nil {
+			viper.AddConfigPath(configDir)
+		} else {
+			viper.AddConfigPath(filepath.Join(homeDir, ".config", "tmuxai"))
+		}
 	}
 
 	// Environment variables


### PR DESCRIPTION
## Summary

Closes #134

Adds support for specifying a custom config file path, as requested.

## Changes

- **`--config <path>` CLI flag** — pass any config file path at startup
- **`TMUXAI_CONFIG` env var** — set once in your shell profile, no flag needed every time
- **Backward compatible** — `Load()` accepts an optional variadic arg, all existing callers unchanged

## Usage

```bash
# Via flag
tmuxai --config /path/to/my/config.yaml

# Via env var
export TMUXAI_CONFIG=/path/to/my/config.yaml
tmuxai
```

## Priority order
1. `--config` flag (highest)
2. `TMUXAI_CONFIG` env var
3. Default `~/.config/tmuxai/config.yaml`

## Testing
- `go build ./...` ✅
- `go test ./...` ✅