### PR TITLE
feat: add SKILLS.md loading system

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@
   - [Creating Knowledge Bases](#creating-knowledge-bases)
   - [Using Knowledge Bases](#using-knowledge-bases)
   - [Auto-Loading Knowledge Bases](#auto-loading-knowledge-bases)
+- [Skills](#skills)
+  - [Enabling Skills](#enabling-skills)
+  - [Creating Skills](#creating-skills)
+  - [Using Skills](#using-skills)
+  - [Auto-Match](#auto-match)
+  - [Budget Controls](#budget-controls)
 - [Model Configuration](#model-configuration)
   - [Setting Up Multiple Models](#setting-up-multiple-models)
   - [Switching Between Models](#switching-between-models)
@@ -427,6 +433,142 @@ knowledge_base:
 - Use `/info` to see how many tokens your loaded KBs are using
 - Knowledge bases are injected after the system prompt but before conversation history
 - Unloading a KB removes it from future messages immediately
+
+## Skills
+
+The Skills feature extends the Knowledge Base system with structured, metadata-rich instructions that teach TmuxAI new capabilities. Unlike KBs (which provide passive reference material), skills can be auto-discovered, lazily loaded, and optionally auto-matched to incoming messages.
+
+Each skill lives in a directory with a `SKILL.md` file containing frontmatter metadata and body content. Ancillary files (scripts, templates, reference docs) can coexist in the same directory.
+
+### Enabling Skills
+
+Skills are **disabled by default**. Enable them in `~/.config/tmuxai/config.yaml`:
+```yaml
+knowledge_base:
+  skills:
+    enabled: true
+```
+
+### Creating Skills
+
+Skills are stored in `~/.config/tmuxai/skills/<skill-name>/`:
+
+```bash
+mkdir -p ~/.config/tmuxai/skills/git-hooks
+```
+
+Create `SKILL.md` with frontmatter:
+```bash
+cat > ~/.config/tmuxai/skills/git-hooks/SKILL.md << 'EOF'
+---
+name: git-hooks
+description: Git pre-commit and linting setup. Auto-stage hooks, conventional commits, branch protection.
+disable-model-invocation: false
+---
+
+# Git Hooks Guide
+
+## Pre-commit Setup
+
+```bash
+git config core.hooksPath .husky
+npm install husky --save-dev
+```
+
+...rest of the skill body...
+EOF
+```
+
+**Frontmatter fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique skill name (must match directory name, alphanumeric + hyphens only) |
+| `description` | Yes | Brief description shown in L1 discovery block and `/skill list` |
+| `disable-model-invocation` | No | If `true`, disables auto-match — skill must be loaded manually |
+
+Optional ancillary files (`.sh`, `.txt`, `.py`, `.json`) can be placed alongside `SKILL.md` and are automatically included when the skill is loaded.
+
+### Using Skills
+
+```bash
+# List available skills
+TmuxAI » /skill
+Available skills:
+  [ ] docker-workflows
+  [ ] git-hooks                [manual]
+  [ ] terraform-best-practices
+
+# Load a skill (lazy-load body + ancillary files)
+TmuxAI » /skill load git-hooks
+✓ Loaded skill: git-hooks (1,240 chars)
+
+# List again to see loaded status
+TmuxAI » /skill
+Available skills:
+  [✓] docker-workflows               (850 chars)
+  [✓] git-hooks                      (1,240 chars)
+  [ ] terraform-best-practices
+
+Loaded: 2/3 skill(s), 2,090/32,000 chars
+
+# View skill details without loading body
+TmuxAI » /skill info git-hooks
+Name:        git-hooks
+Description: Git pre-commit and linting setup.
+Disabled:    false
+Loaded:      true
+Body Size:   1,240 chars
+Directory:   ~/.config/tmuxai/skills/git-hooks
+File:        ~/.config/tmuxai/skills/git-hooks/SKILL.md
+
+# Validate all skills
+TmuxAI » /skill validate
+Validated 3 skill(s):
+  ✓ OK  docker-workflows
+  ✓ OK  git-hooks
+  ✓ OK  terraform-best-practices
+
+# Unload a skill
+TmuxAI » /skill unload git-hooks
+✓ Unloaded skill: git-hooks
+
+# Unload all skills
+TmuxAI » /skill unload --all
+✓ Unloaded all skills (2 skill(s))
+```
+
+### Auto-Match
+
+You can enable automatic skill matching against incoming messages:
+
+```yaml
+knowledge_base:
+  skills:
+    enabled: true
+    auto_match: true
+    threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
+```
+
+With auto-match enabled, TmuxAI analyzes incoming messages and loads relevant skills based on term frequency and description relevance. Skills marked `[manual]` (via `disable-model-invocation: true`) require explicit loading.
+
+### Budget Controls
+
+Skills share context budget with your conversation. Defaults:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `max_l1_chars` | 8,000 | Maximum chars for the L1 discovery block |
+| `max_loaded_chars` | 32,000 | Maximum chars across all loaded skill bodies |
+| `max_skill_chars` | 20,000 | Maximum chars per individual skill body |
+
+Use `/info` to monitor context usage with skills loaded.
+
+**Important Notes:**
+- Skills are injected after the system prompt and KBs, before conversation history
+- The L1 discovery block tells the model which skills exist and their load status
+- Body content is only loaded on demand (lazy loading)
+- A 1MB cap per SKILL.md prevents runaway memory usage
 
 ## Model Configuration
 

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ knowledge_base:
   skills:
     enabled: true
     auto_match: true
-    threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
+    auto_match_threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
 ```
 
 With auto-match enabled, TmuxAI analyzes incoming messages and loads relevant skills based on term frequency and description relevance. Skills marked `[manual]` (via `disable-model-invocation: true`) require explicit loading.
@@ -569,6 +569,7 @@ Use `/info` to monitor context usage with skills loaded.
 - The L1 discovery block tells the model which skills exist and their load status
 - Body content is only loaded on demand (lazy loading)
 - A 1MB cap per SKILL.md prevents runaway memory usage
+- SKILL.md frontmatter fences (`---`) are matched line-by-line; standalone `---` lines in multi-line YAML values will be misinterpreted as the closing fence
 
 ## Model Configuration
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ EOF
 | `description` | Yes | Brief description shown in L1 discovery block and `/skill list` |
 | `disable-model-invocation` | No | If `true`, disables auto-match — skill must be loaded manually |
 
-Optional ancillary files (`.sh`, `.txt`, `.py`, `.json`) can be placed alongside `SKILL.md` and are automatically included when the skill is loaded.
+Optional ancillary files (`.sh`, `.txt`, `.py`, `.json`) can be placed alongside `SKILL.md`. When a skill is loaded, TmuxAI includes a manifest listing those helper file paths so the model can request them if needed.
 
 ### Using Skills
 
@@ -499,7 +499,7 @@ Available skills:
   [ ] git-hooks                [manual]
   [ ] terraform-best-practices
 
-# Load a skill (lazy-load body + ancillary files)
+# Load a skill (lazy-load body + ancillary file manifest)
 TmuxAI » /skill load git-hooks
 ✓ Loaded skill: git-hooks (1,240 chars)
 
@@ -560,7 +560,7 @@ Skills share context budget with your conversation. Defaults:
 |---------|---------|-------------|
 | `max_l1_chars` | 8,000 | Maximum chars for the L1 discovery block |
 | `max_loaded_chars` | 32,000 | Maximum chars across all loaded skill bodies |
-| `max_skill_chars` | 20,000 | Maximum chars per individual skill body |
+| `max_skill_chars` | 20,000 | Maximum chars per individual skill body; set to `0` to disable the per-skill cap |
 
 Use `/info` to monitor context usage with skills loaded.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,7 +111,7 @@ knowledge_base:
     auto_match_threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
     max_l1_chars: 8000        # L1 discovery block char budget
     max_loaded_chars: 32000   # Total loaded skill bodies char budget
-    max_skill_chars: 0        # Per-skill char cap (0 = unlimited, 1MB hard limit)
+    max_skill_chars: 20000    # Per-skill char cap (set 0 for unlimited; 1MB hard limit)
     truncate_desc_at: 200     # Truncate descriptions in L1 block
 
 # Prompts customization, see prompts.go for more details

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -107,7 +107,7 @@ knowledge_base:
   skills:
     enabled: false  # Disabled by default; set true to enable
     auto_scan: true
-    auto_match: true
+    auto_match: false
     auto_match_threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
     max_l1_chars: 8000        # L1 discovery block char budget
     max_loaded_chars: 32000   # Total loaded skill bodies char budget

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,6 +102,18 @@ blacklist_patterns:
   - 'mv\s+'
   - 'dd\s+'
 
+# Knowledge Base: Skills system (opt-in)
+knowledge_base:
+  skills:
+    enabled: false  # Disabled by default; set true to enable
+    auto_scan: true
+    auto_match: true
+    auto_match_threshold: 0.1  # Match sensitivity (0.0–1.0, lower = more aggressive)
+    max_l1_chars: 8000        # L1 discovery block char budget
+    max_loaded_chars: 32000   # Total loaded skill bodies char budget
+    max_skill_chars: 0        # Per-skill char cap (0 = unlimited, 1MB hard limit)
+    truncate_desc_at: 200     # Truncate descriptions in L1 block
+
 # Prompts customization, see prompts.go for more details
 prompts:
   base_system: |

--- a/config/config.go
+++ b/config/config.go
@@ -75,10 +75,23 @@ type PromptsConfig struct {
 	Watch                 string `mapstructure:"watch"`
 }
 
+// SkillsConfig holds skill system configuration
+type SkillsConfig struct {
+	Enabled            bool    `mapstructure:"enabled"`
+	AutoScan           bool    `mapstructure:"auto_scan"`
+	AutoMatch          bool    `mapstructure:"auto_match"`
+	AutoMatchThreshold float64 `mapstructure:"auto_match_threshold"`
+	MaxL1Chars         int     `mapstructure:"max_l1_chars"`
+	MaxLoadedChars     int     `mapstructure:"max_loaded_chars"`
+	MaxSkillChars      int     `mapstructure:"max_skill_chars"`
+	TruncateDescAt     int     `mapstructure:"truncate_desc_at"`
+}
+
 // KnowledgeBaseConfig holds knowledge base configuration
 type KnowledgeBaseConfig struct {
-	AutoLoad []string `mapstructure:"auto_load"`
-	Path     string   `mapstructure:"path"`
+	AutoLoad []string     `mapstructure:"auto_load"`
+	Path     string       `mapstructure:"path"`
+	Skills   SkillsConfig `mapstructure:"skills"`
 }
 
 // TmuxConfig holds tmux-specific behavior settings.
@@ -120,6 +133,16 @@ func DefaultConfig() *Config {
 		KnowledgeBase: KnowledgeBaseConfig{
 			AutoLoad: []string{},
 			Path:     "",
+			Skills: SkillsConfig{
+				Enabled:            false,
+				AutoScan:           true,
+				AutoMatch:          false,
+				AutoMatchThreshold: 0.1,
+				MaxL1Chars:         8000,
+				MaxLoadedChars:     32000,
+				MaxSkillChars:      20000,
+				TruncateDescAt:     200,
+			},
 		},
 	}
 }

--- a/internal/chat.go
+++ b/internal/chat.go
@@ -288,6 +288,44 @@ func (c *CLIInterface) newCompleter() *completion.CmdCompletionOrList2 {
 					return availableModels, availableModels
 				}
 			}
+
+			// Handle /skill subcommands
+			if len(field) > 0 && field[0] == "/skill" {
+				if len(field) == 1 || (len(field) == 2 && !strings.HasSuffix(field[1], " ")) {
+					return []string{"list ", "load ", "unload ", "info ", "validate "}, []string{"list ", "load ", "unload ", "info ", "validate "}
+				} else if len(field) >= 2 && field[1] == "load" {
+					// Complete with skill names
+					if c.manager.Skills != nil {
+						var skillNames []string
+						for name := range c.manager.Skills.Skills {
+							skillNames = append(skillNames, name)
+						}
+						return skillNames, skillNames
+					}
+				} else if len(field) >= 2 && field[1] == "info" {
+					// Complete with skill names
+					if c.manager.Skills != nil {
+						var skillNames []string
+						for name := range c.manager.Skills.Skills {
+							skillNames = append(skillNames, name)
+						}
+						return skillNames, skillNames
+					}
+				} else if len(field) >= 2 && field[1] == "unload" {
+					// Complete with loaded skill names and --all
+					var unloadTargets []string
+					unloadTargets = append(unloadTargets, "--all ")
+					if c.manager.Skills != nil {
+						for name, skill := range c.manager.Skills.Skills {
+							if skill.Loaded {
+								unloadTargets = append(unloadTargets, name+" ")
+							}
+						}
+					}
+					return unloadTargets, unloadTargets
+				}
+			}
+
 			return nil, nil
 		},
 	}

--- a/internal/chat_command.go
+++ b/internal/chat_command.go
@@ -460,32 +460,33 @@ Watch for: ` + watchDesc
 
 		// /skill validate
 		if len(parts) == 2 && parts[1] == "validate" {
-			names := make([]string, 0, len(m.Skills.Skills))
-			for name := range m.Skills.Skills {
+			// Re-scan even when startup auto_scan is disabled so validate reports
+			// all valid and invalid on-disk skills.
+			validateConfig := m.Config.KnowledgeBase.Skills
+			validateConfig.AutoScan = true
+			newReg, err := InitSkills(&validateConfig)
+			if err != nil {
+				m.Println(fmt.Sprintf("Validation error: %v", err))
+				return
+			}
+
+			names := make([]string, 0, len(newReg.Skills))
+			for name := range newReg.Skills {
 				names = append(names, name)
 			}
 			sort.Strings(names)
 
 			m.Println(fmt.Sprintf("Validated %d skill(s):", len(names)))
 			for _, name := range names {
-				s := m.Skills.Skills[name]
-				status := "✓ OK"
-				if s.Name == "" {
-					status = "✗ missing name"
-				} else if s.Description == "" {
-					status = "✗ missing description"
-				}
-				m.Println(fmt.Sprintf("  %s  %s", status, name))
+				m.Println(fmt.Sprintf("  ✓ OK  %s", name))
 			}
 
-			// Re-scan to detect new/unregistered skills
-			newReg, err := InitSkills(&m.Config.KnowledgeBase.Skills)
-			if err != nil {
-				m.Println(fmt.Sprintf("Re-scan error: %v", err))
-				return
-			}
-			if len(newReg.Skills) != len(m.Skills.Skills) {
-				m.Println(fmt.Sprintf("\nNote: %d skill(s) discovered during re-scan (currently %d)", len(newReg.Skills), len(m.Skills.Skills)))
+			if len(newReg.DiscoveryWarnings) > 0 {
+				m.Println("")
+				m.Println(fmt.Sprintf("Warnings (%d):", len(newReg.DiscoveryWarnings)))
+				for _, warning := range newReg.DiscoveryWarnings {
+					m.Println(fmt.Sprintf("  ✗ %s", warning))
+				}
 			}
 			return
 		}

--- a/internal/chat_command.go
+++ b/internal/chat_command.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,6 +25,12 @@ const helpMessage = `Available commands:
 - /kb load <name>: Load a knowledge base
 - /kb unload <name>: Unload a knowledge base
 - /kb unload --all: Unload all knowledge bases
+- /skill: List available skills
+- /skill load <name>: Load a skill
+- /skill unload <name>: Unload a skill
+- /skill unload --all: Unload all skills
+- /skill info <name>: Show skill details
+- /skill validate: Re-scan and validate skills
 - /exit: Exit the application`
 
 var commands = []string{
@@ -38,6 +45,7 @@ var commands = []string{
 	"/squash",
 	"/model",
 	"/kb",
+	"/skill",
 }
 
 // checks if the given content is a command
@@ -307,6 +315,184 @@ Watch for: ` + watchDesc
 			return
 		}
 
+	case prefixMatch(commandPrefix, "/skill"):
+		// Feature gate
+		if m.Skills == nil || !m.Config.KnowledgeBase.Skills.Enabled {
+			m.Println("Skills system is not enabled. Set knowledge_base.skills.enabled: true in config.")
+			return
+		}
+
+		// /skill or /skill list → show all skills
+		if len(parts) == 1 || (len(parts) == 2 && parts[1] == "list") {
+			names := make([]string, 0, len(m.Skills.Skills))
+			for name := range m.Skills.Skills {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			if len(names) == 0 {
+				m.Println("No skills discovered.")
+				return
+			}
+
+			m.Println("Available skills:")
+			for _, name := range names {
+				s := m.Skills.Skills[name]
+				loaded := "[ ]"
+				if s.Loaded {
+					loaded = "[✓]"
+				}
+				disabled := ""
+				if s.Disabled {
+					disabled = " [manual]"
+				}
+				charInfo := ""
+				if s.Loaded {
+					charInfo = fmt.Sprintf(" (%d chars)", s.BodyLength)
+				}
+				m.Println(fmt.Sprintf("  %s %-25s%s%s", loaded, name, disabled, charInfo))
+			}
+			total := len(names)
+			loadedCount := 0
+			usedChars := 0
+			for _, s := range m.Skills.Skills {
+				if s.Loaded {
+					loadedCount++
+					usedChars += s.BodyLength
+				}
+			}
+			if loadedCount > 0 {
+				m.Println("")
+				m.Println(fmt.Sprintf("Loaded: %d/%d skill(s), %d/%d chars",
+					loadedCount, total, usedChars, m.Config.KnowledgeBase.Skills.MaxLoadedChars))
+			}
+			return
+		}
+
+		// /skill load <name>
+		if len(parts) >= 2 && parts[1] == "load" {
+			if len(parts) < 3 {
+				m.Println("Usage: /skill load <name>")
+				return
+			}
+			name := parts[2]
+			if _, ok := m.Skills.Skills[name]; !ok {
+				m.Println(fmt.Sprintf("Skill '%s' not found", name))
+				return
+			}
+			if m.Skills.Skills[name].Loaded {
+				m.Println(fmt.Sprintf("Skill '%s' is already loaded", name))
+				return
+			}
+			if err := m.Skills.Load(name); err != nil {
+				m.Println(fmt.Sprintf("Error loading skill '%s': %v", name, err))
+				return
+			}
+			m.Skills.L1Block = m.Skills.BuildL1Block()
+			m.LoadedSkills[name] = m.Skills.Skills[name].Body
+			m.Println(fmt.Sprintf("✓ Loaded skill: %s (%d chars)", name, m.Skills.Skills[name].BodyLength))
+			return
+		}
+
+		// /skill unload <name> or /skill unload --all
+		if len(parts) >= 2 && parts[1] == "unload" {
+			if len(parts) >= 3 && parts[2] == "--all" {
+				names := make([]string, 0, len(m.Skills.Skills))
+				for _, s := range m.Skills.Skills {
+					if s.Loaded {
+						names = append(names, s.Name)
+					}
+				}
+				if len(names) == 0 {
+					m.Println("No skills are currently loaded")
+					return
+				}
+				for _, name := range names {
+					m.Skills.Unload(name)
+					delete(m.LoadedSkills, name)
+				}
+				m.Skills.L1Block = m.Skills.BuildL1Block()
+				m.Println(fmt.Sprintf("✓ Unloaded all skills (%d skill(s))", len(names)))
+				return
+			}
+			if len(parts) < 3 {
+				m.Println("Usage: /skill unload <name> or /skill unload --all")
+				return
+			}
+			name := parts[2]
+			if err := m.Skills.Unload(name); err != nil {
+				m.Println(fmt.Sprintf("Error: %v", err))
+				return
+			}
+			delete(m.LoadedSkills, name)
+			m.Skills.L1Block = m.Skills.BuildL1Block()
+			m.Println(fmt.Sprintf("✓ Unloaded skill: %s", name))
+			return
+		}
+
+		// /skill info <name>
+		if len(parts) >= 2 && parts[1] == "info" {
+			if len(parts) < 3 {
+				m.Println("Usage: /skill info <name>")
+				return
+			}
+			name := parts[2]
+			skill, ok := m.Skills.Skills[name]
+			if !ok {
+				m.Println(fmt.Sprintf("Skill '%s' not found", name))
+				return
+			}
+			m.Println(fmt.Sprintf("Name:        %s", skill.Name))
+			m.Println(fmt.Sprintf("Description: %s", skill.Description))
+			m.Println(fmt.Sprintf("Disabled:    %v", skill.Disabled))
+			m.Println(fmt.Sprintf("Loaded:      %v", skill.Loaded))
+			m.Println(fmt.Sprintf("Body Size:   %d chars", skill.BodyLength))
+			m.Println(fmt.Sprintf("Directory:   %s", skill.DirPath))
+			m.Println(fmt.Sprintf("File:        %s", skill.FilePath))
+			// Show ancillary files
+			manifest := skill.BuildManifest()
+			if manifest != "" {
+				m.Println("")
+				m.Println(manifest)
+			}
+			return
+		}
+
+		// /skill validate
+		if len(parts) == 2 && parts[1] == "validate" {
+			names := make([]string, 0, len(m.Skills.Skills))
+			for name := range m.Skills.Skills {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			m.Println(fmt.Sprintf("Validated %d skill(s):", len(names)))
+			for _, name := range names {
+				s := m.Skills.Skills[name]
+				status := "✓ OK"
+				if s.Name == "" {
+					status = "✗ missing name"
+				} else if s.Description == "" {
+					status = "✗ missing description"
+				}
+				m.Println(fmt.Sprintf("  %s  %s", status, name))
+			}
+
+			// Re-scan to detect new/unregistered skills
+			newReg, err := InitSkills(&m.Config.KnowledgeBase.Skills)
+			if err != nil {
+				m.Println(fmt.Sprintf("Re-scan error: %v", err))
+				return
+			}
+			if len(newReg.Skills) != len(m.Skills.Skills) {
+				m.Println(fmt.Sprintf("\nNote: %d skill(s) discovered during re-scan (currently %d)", len(newReg.Skills), len(m.Skills.Skills)))
+			}
+			return
+		}
+
+		m.Println("Usage: /skill [list|load <name>|unload <name>|unload --all|info <name>|validate]")
+		return
+
 	default:
 		m.Println(fmt.Sprintf("Unknown command: %s. Type '/help' to see available commands.", command))
 		return
@@ -378,6 +564,11 @@ func (m *Manager) formatInfo() {
 	if len(m.LoadedKBs) > 0 {
 		kbTokens := m.getTotalLoadedKBTokens()
 		formatLine("Loaded KBs", fmt.Sprintf("%d (%d tokens)", len(m.LoadedKBs), kbTokens))
+	}
+
+	// Display loaded skills information
+	if m.Skills != nil && len(m.LoadedSkills) > 0 {
+		formatLine("Loaded Skills", fmt.Sprintf("%d (%d chars)", len(m.LoadedSkills), m.Skills.UsedChars))
 	}
 
 	// Display tmux panes section

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -48,6 +48,8 @@ type Manager struct {
 	OS                string
 	SessionOverrides  map[string]interface{} // session-only config overrides
 	LoadedKBs         map[string]string      // Loaded knowledge bases (name -> content)
+	LoadedSkills      map[string]string      // Loaded skill bodies + manifests (name -> content)
+	Skills            *SkillRegistry         // Skill registry (discovery, L1, budget)
 	ForcedExecPaneID  string
 	ForcedReadPaneIDs map[string]bool
 
@@ -91,6 +93,7 @@ func NewManager(cfg *config.Config, options ManagerOptions) (*Manager, error) {
 		OS:                os,
 		SessionOverrides:  make(map[string]interface{}),
 		LoadedKBs:         make(map[string]string),
+		LoadedSkills:      make(map[string]string),
 		ForcedExecPaneID:  options.ForcedExecPaneID,
 		ForcedReadPaneIDs: make(map[string]bool),
 	}
@@ -111,6 +114,16 @@ func NewManager(cfg *config.Config, options ManagerOptions) (*Manager, error) {
 
 	// Auto-load knowledge bases from config
 	manager.autoLoadKBs()
+
+	// Initialize skill registry if enabled
+	if manager.Config.KnowledgeBase.Skills.Enabled {
+		reg, err := InitSkills(&manager.Config.KnowledgeBase.Skills)
+		if err != nil {
+			logger.Info("Skill initialization failed: %v", err)
+		} else {
+			manager.Skills = reg
+		}
+	}
 
 	return manager, nil
 }

--- a/internal/process_message.go
+++ b/internal/process_message.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/alvinunreal/tmuxai/logger"
@@ -78,7 +79,14 @@ func (m *Manager) ProcessUserMessage(ctx context.Context, message string) bool {
 	}
 
 	// Inject loaded skill bodies (m.LoadedSkills map)
-	for skillName, skillContent := range m.LoadedSkills {
+	// Sort keys for deterministic injection order
+	skillNames := make([]string, 0, len(m.LoadedSkills))
+	for skillName := range m.LoadedSkills {
+		skillNames = append(skillNames, skillName)
+	}
+	sort.Strings(skillNames)
+	for _, skillName := range skillNames {
+		skillContent := m.LoadedSkills[skillName]
 		history = append(history, ChatMessage{
 			Content:   fmt.Sprintf("=== Skill: %s ===\n%s", skillName, skillContent),
 			FromUser:  false,

--- a/internal/process_message.go
+++ b/internal/process_message.go
@@ -39,6 +39,24 @@ func (m *Manager) ProcessUserMessage(ctx context.Context, message string) bool {
 		Timestamp: time.Now(),
 	}
 
+	// Auto-match skills against incoming message
+	if m.Skills != nil && m.Config.KnowledgeBase.Skills.AutoMatch {
+		matches := m.Skills.AutoMatch(currentMessage.Content)
+		anyLoaded := false
+		for _, skill := range matches {
+			if err := m.Skills.Load(skill.Name); err != nil {
+				logger.Debug("auto-match load failed for '%s': %v", skill.Name, err)
+				continue
+			}
+			m.LoadedSkills[skill.Name] = skill.Body
+			logger.Info("auto-matched skill: %s", skill.Name)
+			anyLoaded = true
+		}
+		if anyLoaded {
+			m.Skills.L1Block = m.Skills.BuildL1Block()
+		}
+	}
+
 	// build current chat history
 	var history []ChatMessage
 	switch {
@@ -59,7 +77,17 @@ func (m *Manager) ProcessUserMessage(ctx context.Context, message string) bool {
 		})
 	}
 
+	// Inject loaded skill bodies (m.LoadedSkills map)
+	for skillName, skillContent := range m.LoadedSkills {
+		history = append(history, ChatMessage{
+			Content:   fmt.Sprintf("=== Skill: %s ===\n%s", skillName, skillContent),
+			FromUser:  false,
+			Timestamp: time.Now(),
+		})
+	}
+
 	history = append(history, m.Messages...)
+
 
 	sending := append(history, currentMessage)
 

--- a/internal/prompts.go
+++ b/internal/prompts.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"strings"
 	"time"
 )
@@ -44,6 +43,13 @@ DO NOT WRITE MORE TEXT AFTER THE TOOL CALLS IN A RESPONSE. You can wait until th
 func (m *Manager) chatAssistantPrompt(prepared bool) ChatMessage {
 	var builder strings.Builder
 	builder.WriteString(m.baseSystemPrompt())
+
+	// Inject L1 skill registry (after base system, before XML tool docs)
+	if m.Skills != nil && m.Skills.L1Block != "" {
+		builder.WriteString(m.Skills.L1Block)
+		builder.WriteString("\n")
+	}
+
 	builder.WriteString(`
 Your primary function is to assist users by interpreting their requests and executing appropriate actions.
 You have access to the following XML tags to control the tmux pane:
@@ -153,8 +159,17 @@ I'll wait for it to complete before proceeding.
 }
 
 func (m *Manager) watchPrompt() ChatMessage {
-	chatPrompt := fmt.Sprintf(`
-%s
+	var builder strings.Builder
+	builder.WriteString("\n")
+	builder.WriteString(m.baseSystemPrompt())
+
+	// Inject L1 skill registry (after base system, before watch-mode instructions)
+	if m.Skills != nil && m.Skills.L1Block != "" {
+		builder.WriteString(m.Skills.L1Block)
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(`
 You are current in watch mode and assisting user by watching the pane content.
 Use your common sense to decide if when it's actually valuable and needed to respond for the given watch goal.
 
@@ -165,14 +180,14 @@ Keep your response short and concise, but they should be informative and valuabl
 If no response is needed, output:
 <NoComment>1</NoComment>
 
-`, m.baseSystemPrompt())
+`)
 
 	if m.Config.Prompts.Watch != "" {
-		chatPrompt = chatPrompt + "\n\n" + m.Config.Prompts.Watch
+		builder.WriteString(m.Config.Prompts.Watch)
 	}
 
 	return ChatMessage{
-		Content:   chatPrompt,
+		Content:   builder.String(),
 		Timestamp: time.Now(),
 		FromUser:  false,
 	}

--- a/internal/skill_registry.go
+++ b/internal/skill_registry.go
@@ -1,0 +1,545 @@
+package internal
+
+import (
+	"fmt"
+	"html"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/alvinunreal/tmuxai/config"
+	"github.com/alvinunreal/tmuxai/logger"
+	"gopkg.in/yaml.v3"
+)
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Skill represents a discovered SKILL.md file.
+type Skill struct {
+	Name        string // from frontmatter, validated against regex
+	Description string // from frontmatter
+	Disabled    bool   // disable-model-invocation flag
+	DirPath     string // absolute path to skill directory (home for ancillary files)
+	FilePath    string // absolute path to SKILL.md
+	Body        string // L2 content + manifest (populated on lazy load only)
+	BodyLength  int    // char count of body + manifest (for budget enforcement)
+	Loaded      bool   // whether body is currently injected
+}
+
+// SkillRegistry manages discovery, storage, and lazy loading of skills.
+type SkillRegistry struct {
+	Skills    map[string]*Skill       // keyed by name
+	Config    *config.SkillsConfig    // pointer to config for budget enforcement
+	L1Block   string                  // pre-rendered <available_skills> XML block
+	UsedChars int                     // aggregate chars of currently loaded skills
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const (
+	maxManifestFiles = 100  // max files to list per skill
+	maxManifestChars = 1024 // max chars for manifest text
+)
+
+const (
+	DefaultMaxL1Chars    = 8000
+	DefaultMaxLoadedChars = 32000
+	DefaultMaxSkillChars  = 20000
+	DefaultTruncateDescAt = 200
+	DefaultAutoMatchThresh = 0.1
+)
+
+// ============================================================================
+// Frontmatter Parser (§14)
+// ============================================================================
+
+var skillNameRegex = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ParseSkillMd splits a SKILL.md byte slice into YAML frontmatter and body.
+//
+// Rules (§14.2):
+//   - Leading "---" (LF or CRLF) signals frontmatter.
+//   - SplitN on "---" yields at most 3 parts: ["", "frontmatter", "body"].
+//   - Body may contain further "---" horizontal rules (handled safely by SplitN).
+//   - No frontmatter → nil meta, entire content as body.
+//   - Malformed YAML → error (caller should reject the skill).
+func ParseSkillMd(raw []byte) (meta map[string]any, body string, err error) {
+	content := string(raw)
+
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		return nil, content, nil
+	}
+
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return nil, content, nil
+	}
+
+	fmStr := strings.TrimSpace(parts[1])
+	bodyStr := strings.TrimSpace(parts[2])
+
+	if fmStr == "" {
+		return nil, bodyStr, nil
+	}
+
+	fm := make(map[string]any)
+	if err := yaml.Unmarshal([]byte(fmStr), &fm); err != nil {
+		return nil, "", fmt.Errorf("invalid YAML frontmatter: %w", err)
+	}
+
+	return fm, bodyStr, nil
+}
+
+// extractSkillMeta extracts name, description, and disabled flag from parsed
+// frontmatter. Missing fields return zero-values.
+func extractSkillMeta(meta map[string]any) (name, description string, disabled bool) {
+	if meta == nil {
+		return
+	}
+	name, _ = meta["name"].(string)
+	name = strings.TrimSpace(name)
+	description, _ = meta["description"].(string)
+	description = strings.TrimSpace(description)
+	disabled, _ = meta["disable-model-invocation"].(bool)
+	return
+}
+
+// validateSkillName enforces kebab-case alphanumeric, 1–64 characters.
+func validateSkillName(name string) bool {
+	if len(name) == 0 || len(name) > 64 {
+		return false
+	}
+	return skillNameRegex.MatchString(name)
+}
+
+// ============================================================================
+// Registry Initialization (§5.1–§5.2)
+// ============================================================================
+
+// InitSkills scans the skills directory, parses each SKILL.md, and builds a
+// SkillRegistry. Returns an empty registry (not an error) if the directory
+// doesn't exist.
+//
+// Directory derivation (§5.1): the skills directory sits alongside the KB
+// directory at ~/.config/tmuxai/skills/ — derived from the same config
+// directory that GetKBDir() uses.
+func InitSkills(sc *config.SkillsConfig) (*SkillRegistry, error) {
+	reg := &SkillRegistry{
+		Skills: make(map[string]*Skill),
+		Config: sc,
+	}
+
+	skillsDir := resolveSkillsDir()
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return reg, nil
+		}
+		return nil, fmt.Errorf("failed to read skills directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dirPath := filepath.Join(skillsDir, entry.Name())
+		skillFile := findSkillMd(dirPath)
+		if skillFile == "" {
+			continue
+		}
+
+		fi, statErr := os.Stat(skillFile)
+		if statErr != nil {
+			continue
+		}
+		if fi.Size() > 1<<20 {
+			logger.Info("SKILL.md %s exceeds 1MB cap, skipping", skillFile)
+			continue
+		}
+
+		raw, err := os.ReadFile(skillFile)
+		if err != nil {
+			continue
+		}
+
+		meta, body, err := ParseSkillMd(raw)
+		if err != nil {
+			continue
+		}
+
+		name, description, disabled := extractSkillMeta(meta)
+		if name == "" || description == "" {
+			continue
+		}
+		if !validateSkillName(name) {
+			continue
+		}
+		if name != entry.Name() {
+			continue
+		}
+
+		reg.Skills[name] = &Skill{
+			Name:        name,
+			Description: description,
+			Disabled:    disabled,
+			DirPath:     dirPath,
+			FilePath:    skillFile,
+			Body:        "",
+			BodyLength:  len(body),
+			Loaded:      false,
+		}
+	}
+
+	reg.L1Block = reg.BuildL1Block()
+	return reg, nil
+}
+
+// resolveSkillsDir locates the skills directory at ~/.config/tmuxai/skills/
+// using the same derivation path as GetKBDir() — sibling to kb/ under the
+// tmuxai config directory.
+func resolveSkillsDir() string {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "skills")
+}
+
+// findSkillMd searches a directory for a file named SKILL.md (case-insensitive).
+func findSkillMd(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.EqualFold(e.Name(), "SKILL.md") {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	return ""
+}
+
+// ============================================================================
+// L1 Block Builder (§5.3)
+// ============================================================================
+
+// BuildL1Block renders the <available_skills> XML block. Skills are sorted
+// by name. Budget enforcement skips skills exceeding max chars.
+func (r *SkillRegistry) BuildL1Block() string {
+	maxChars := r.budgetMaxL1()
+	var buf strings.Builder
+	buf.WriteString("\n<available_skills>\n")
+
+	names := make([]string, 0, len(r.Skills))
+	for n := range r.Skills {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	trunc := r.budgetTruncateDesc()
+
+	for _, name := range names {
+		s := r.Skills[name]
+		marker := ""
+		if s.Disabled {
+			marker = " [manual]"
+		}
+
+		desc := s.Description
+		if len(desc) > trunc {
+			desc = desc[:trunc] + "..."
+		}
+
+		line := fmt.Sprintf(
+			"  <skill loaded=\"%v\">\n    <name>%s%s</name>\n    <description>%s</description>\n    <location>%s</location>\n  </skill>\n",
+			s.Loaded, s.Name, marker, html.EscapeString(desc), s.FilePath)
+
+		if buf.Len()+len(line) > maxChars {
+			buf.WriteString("  <!-- remaining skills omitted due to L1 budget -->\n")
+			break
+		}
+		buf.WriteString(line)
+	}
+
+	buf.WriteString("</available_skills>\n")
+	return buf.String()
+}
+
+// ============================================================================
+// Ancillary File Manifest (§6.4)
+// ============================================================================
+
+// BuildManifest walks the skill directory, collects non-SKILL.md files,
+// and returns a formatted manifest. Caps at maxManifestFiles / maxManifestChars.
+// Returns "" if there are no ancillary files.
+func (s *Skill) BuildManifest() string {
+	var files []string
+	err := filepath.WalkDir(s.DirPath, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(filepath.Base(p), "SKILL.md") {
+			return nil
+		}
+		files = append(files, p)
+		return nil
+	})
+	if err != nil || len(files) == 0 {
+		return ""
+	}
+
+	sort.Strings(files)
+	if len(files) > maxManifestFiles {
+		files = files[:maxManifestFiles]
+	}
+
+	var buf strings.Builder
+	buf.WriteString("--- Skill File Manifest: " + s.Name + " ---\n")
+	buf.WriteString("The following helper files are available in the skill directory.\n")
+	buf.WriteString("Use their full paths to read (cat/head) or execute (bash) them as needed.\n\n")
+
+	for _, f := range files {
+		rel, _ := filepath.Rel(s.DirPath, f)
+		line := fmt.Sprintf("  %-35s → %s\n", rel, f)
+		if buf.Len()+len(line) > maxManifestChars {
+			buf.WriteString("  ... (manifest truncated)\n")
+			break
+		}
+		buf.WriteString(line)
+	}
+	buf.WriteString("--- End Manifest ---\n")
+	return buf.String()
+}
+
+// ============================================================================
+// Load / Unload (§7.3)
+// ============================================================================
+
+// Load reads a skill body + manifest from disk, enforces budgets, and stores it.
+func (r *SkillRegistry) Load(name string) error {
+	skill, ok := r.Skills[name]
+	if !ok {
+		return fmt.Errorf("skill '%s' not found", name)
+	}
+	if skill.Loaded {
+		return nil
+	}
+
+	fi, statErr := os.Stat(skill.FilePath)
+	if statErr == nil && fi.Size() > 1<<20 {
+		return fmt.Errorf("skill '%s' SKILL.md exceeds 1MB cap", name)
+	}
+
+	raw, err := os.ReadFile(skill.FilePath)
+	if err != nil {
+		return fmt.Errorf("read skill '%s': %w", name, err)
+	}
+
+	_, body, err := ParseSkillMd(raw)
+	if err != nil {
+		return fmt.Errorf("parse skill '%s': %w", name, err)
+	}
+
+	manifest := skill.BuildManifest()
+	content := body
+	if manifest != "" {
+		content = body + "\n\n" + manifest
+	}
+
+	bodyChars := len(content)
+
+	// Per-skill cap.
+	maxSkill := r.budgetMaxSkill()
+	if bodyChars > maxSkill {
+		content = content[:maxSkill] + "\n\n...[skill body truncated]"
+		bodyChars = maxSkill
+	}
+
+	// Aggregate cap.
+	maxLoaded := r.budgetMaxLoaded()
+	if r.UsedChars+bodyChars > maxLoaded {
+		return fmt.Errorf(
+			"skill '%s' (%d chars) would exceed aggregate budget (%d/%d)",
+			name, bodyChars, r.UsedChars, maxLoaded)
+	}
+
+	skill.Body = content
+	skill.BodyLength = bodyChars
+	skill.Loaded = true
+	r.UsedChars += bodyChars
+	r.Skills[name] = skill
+	return nil
+}
+
+// Unload clears a loaded skill's body and restores UsedChars.
+func (r *SkillRegistry) Unload(name string) error {
+	skill, ok := r.Skills[name]
+	if !ok || !skill.Loaded {
+		return fmt.Errorf("skill '%s' is not loaded", name)
+	}
+
+	r.UsedChars -= skill.BodyLength
+	if r.UsedChars < 0 {
+		r.UsedChars = 0
+	}
+	skill.Body = ""
+	skill.BodyLength = 0
+	skill.Loaded = false
+	r.Skills[name] = skill
+	return nil
+}
+
+// ============================================================================
+// Auto-Match (§7.2)
+// ============================================================================
+
+// stopWords is the English stopword set used by tokenize.
+var stopWords = map[string]bool{
+	"the": true, "and": true, "for": true, "not": true, "you": true,
+	"all": true, "can": true, "had": true, "her": true, "was": true,
+	"one": true, "our": true, "out": true, "are": true, "has": true,
+	"have": true, "from": true, "been": true, "some": true, "them": true,
+	"than": true, "its": true, "over": true, "such": true, "that": true,
+	"with": true, "will": true, "this": true, "each": true, "when": true,
+	"use": true, "how": true, "which": true, "their": true, "what": true,
+}
+
+// tokenize lowercases, strips ASCII punctuation, drops stopwords and
+// tokens ≤ 2 characters.
+func tokenize(text string) []string {
+	words := strings.Fields(strings.ToLower(text))
+	var result []string
+	for _, w := range words {
+		w = strings.Trim(w, ".,;:!?()[]{}\"'/\\`~")
+		if len(w) > 2 && !stopWords[w] {
+			result = append(result, w)
+		}
+	}
+	return result
+}
+
+type scoredSkill struct {
+	skill *Skill
+	score float64
+}
+
+// AutoMatch scores each eligible skill against the context string using
+// IDF-weighted keyword overlap (§7.2). Excludes disabled and already-loaded
+// skills. Returns candidates sorted by score descending, name ascending.
+func (r *SkillRegistry) AutoMatch(context string) []*Skill {
+	ctxTokens := tokenize(context)
+	if len(ctxTokens) == 0 {
+		return nil
+	}
+
+	// Build IDF: document frequency across skill descriptions.
+	idf := make(map[string]float64)
+	docCount := 0
+	var eligible []*Skill
+
+	for _, skill := range r.Skills {
+		if skill.Disabled || skill.Loaded {
+			continue
+		}
+		docCount++
+		eligible = append(eligible, skill)
+		seen := make(map[string]bool)
+		for _, w := range tokenize(skill.Description) {
+			if !seen[w] {
+				idf[w]++
+				seen[w] = true
+			}
+		}
+	}
+	if docCount == 0 {
+		return nil
+	}
+
+	for w := range idf {
+		idf[w] = math.Log(float64(docCount)/idf[w]) + 1
+	}
+
+	threshold := r.budgetMatchThreshold()
+	var candidates []scoredSkill
+
+	for _, skill := range eligible {
+		descTokens := tokenize(skill.Description)
+		if len(descTokens) == 0 {
+			continue
+		}
+
+		matchSum := 0.0
+		for _, w := range descTokens {
+			for _, cw := range ctxTokens {
+				if w == cw {
+					matchSum += idf[w]
+				}
+			}
+		}
+
+		score := matchSum / float64(len(descTokens))
+		if score >= threshold {
+			candidates = append(candidates, scoredSkill{skill, score})
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].skill.Name < candidates[j].skill.Name
+	})
+
+	results := make([]*Skill, len(candidates))
+	for i, c := range candidates {
+		results[i] = c.skill
+	}
+	return results
+}
+
+// ============================================================================
+// Budget Accessors (private helpers — defaults when config is nil/zero)
+// ============================================================================
+
+func (r *SkillRegistry) budgetMaxL1() int {
+	if r.Config == nil || r.Config.MaxL1Chars <= 0 {
+		return DefaultMaxL1Chars
+	}
+	return r.Config.MaxL1Chars
+}
+
+func (r *SkillRegistry) budgetMaxLoaded() int {
+	if r.Config == nil || r.Config.MaxLoadedChars <= 0 {
+		return DefaultMaxLoadedChars
+	}
+	return r.Config.MaxLoadedChars
+}
+
+func (r *SkillRegistry) budgetMaxSkill() int {
+	if r.Config == nil || r.Config.MaxSkillChars <= 0 {
+		return DefaultMaxSkillChars
+	}
+	return r.Config.MaxSkillChars
+}
+
+func (r *SkillRegistry) budgetTruncateDesc() int {
+	if r.Config == nil || r.Config.TruncateDescAt <= 0 {
+		return DefaultTruncateDescAt
+	}
+	return r.Config.TruncateDescAt
+}
+
+func (r *SkillRegistry) budgetMatchThreshold() float64 {
+	if r.Config == nil || r.Config.AutoMatchThreshold <= 0 {
+		return DefaultAutoMatchThresh
+	}
+	return r.Config.AutoMatchThreshold
+}

--- a/internal/skill_registry.go
+++ b/internal/skill_registry.go
@@ -33,10 +33,11 @@ type Skill struct {
 
 // SkillRegistry manages discovery, storage, and lazy loading of skills.
 type SkillRegistry struct {
-	Skills    map[string]*Skill    // keyed by name
-	Config    *config.SkillsConfig // pointer to config for budget enforcement
-	L1Block   string               // pre-rendered <available_skills> XML block
-	UsedChars int                  // aggregate chars of currently loaded skills
+	Skills            map[string]*Skill    // keyed by name
+	Config            *config.SkillsConfig // pointer to config for budget enforcement
+	L1Block           string               // pre-rendered <available_skills> XML block
+	UsedChars         int                  // aggregate chars of currently loaded skills
+	DiscoveryWarnings []string             // non-fatal validation warnings from discovery
 }
 
 // ============================================================================
@@ -159,8 +160,9 @@ func validateSkillName(name string) bool {
 // directory that GetKBDir() uses.
 func InitSkills(sc *config.SkillsConfig) (*SkillRegistry, error) {
 	reg := &SkillRegistry{
-		Skills: make(map[string]*Skill),
-		Config: sc,
+		Skills:            make(map[string]*Skill),
+		Config:            sc,
+		DiscoveryWarnings: []string{},
 	}
 	reg.L1Block = reg.BuildL1Block()
 
@@ -185,36 +187,48 @@ func InitSkills(sc *config.SkillsConfig) (*SkillRegistry, error) {
 		dirPath := filepath.Join(skillsDir, entry.Name())
 		skillFile := findSkillMd(dirPath)
 		if skillFile == "" {
+			reg.addDiscoveryWarning(entry.Name(), "missing SKILL.md")
 			continue
 		}
 
 		fi, statErr := os.Stat(skillFile)
 		if statErr != nil {
+			reg.addDiscoveryWarning(entry.Name(), fmt.Sprintf("cannot stat SKILL.md: %v", statErr))
 			continue
 		}
 		if fi.Size() > 1<<20 {
+			reg.addDiscoveryWarning(entry.Name(), "SKILL.md exceeds 1MB cap")
 			logger.Info("SKILL.md %s exceeds 1MB cap, skipping", skillFile)
 			continue
 		}
 
 		raw, err := os.ReadFile(skillFile)
 		if err != nil {
+			reg.addDiscoveryWarning(entry.Name(), fmt.Sprintf("cannot read SKILL.md: %v", err))
 			continue
 		}
 
 		meta, body, err := ParseSkillMd(raw)
 		if err != nil {
+			reg.addDiscoveryWarning(entry.Name(), fmt.Sprintf("invalid frontmatter: %v", err))
 			continue
 		}
 
 		name, description, disabled := extractSkillMeta(meta)
-		if name == "" || description == "" {
+		if name == "" {
+			reg.addDiscoveryWarning(entry.Name(), "missing required frontmatter field: name")
+			continue
+		}
+		if description == "" {
+			reg.addDiscoveryWarning(entry.Name(), "missing required frontmatter field: description")
 			continue
 		}
 		if !validateSkillName(name) {
+			reg.addDiscoveryWarning(entry.Name(), fmt.Sprintf("invalid skill name %q", name))
 			continue
 		}
 		if name != entry.Name() {
+			reg.addDiscoveryWarning(entry.Name(), fmt.Sprintf("frontmatter name %q does not match directory name", name))
 			continue
 		}
 
@@ -232,6 +246,10 @@ func InitSkills(sc *config.SkillsConfig) (*SkillRegistry, error) {
 
 	reg.L1Block = reg.BuildL1Block()
 	return reg, nil
+}
+
+func (r *SkillRegistry) addDiscoveryWarning(skillDir, reason string) {
+	r.DiscoveryWarnings = append(r.DiscoveryWarnings, fmt.Sprintf("%s: %s", skillDir, reason))
 }
 
 // resolveSkillsDir locates the skills directory at ~/.config/tmuxai/skills/

--- a/internal/skill_registry.go
+++ b/internal/skill_registry.go
@@ -65,11 +65,38 @@ var skillNameRegex = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 // ParseSkillMd splits a SKILL.md byte slice into YAML frontmatter and body.
 //
 // Rules (§14.2):
-//   - Leading "---" (LF or CRLF) signals frontmatter.
-//   - SplitN on "---" yields at most 3 parts: ["", "frontmatter", "body"].
-//   - Body may contain further "---" horizontal rules (handled safely by SplitN).
+//   - Opening/closing "---" lines signal frontmatter (matched line-by-line via splitFrontmatter).
+//   - Standalone "---" lines (trimmed) serve as fences; embedded "---" in YAML values is preserved.
+//   - Body may contain further "---" horizontal rules (not mistaken for fences unless alone on a line).
 //   - No frontmatter → nil meta, entire content as body.
 //   - Malformed YAML → error (caller should reject the skill).
+func splitFrontmatter(content string) (frontmatter, body string, ok bool) {
+	lines := strings.Split(content, "\n")
+	// Find opening ---
+	openIdx := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == "---" {
+			openIdx = i
+			break
+		}
+	}
+	if openIdx == -1 {
+		return "", "", false
+	}
+	// Find closing ---
+	closeIdx := -1
+	for i := openIdx + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			closeIdx = i
+			break
+		}
+	}
+	if closeIdx == -1 {
+		return "", "", false
+	}
+	return strings.Join(lines[openIdx+1:closeIdx], "\n"), strings.Join(lines[closeIdx+1:], "\n"), true
+}
+
 func ParseSkillMd(raw []byte) (meta map[string]any, body string, err error) {
 	content := string(raw)
 
@@ -77,13 +104,13 @@ func ParseSkillMd(raw []byte) (meta map[string]any, body string, err error) {
 		return nil, content, nil
 	}
 
-	parts := strings.SplitN(content, "---", 3)
-	if len(parts) < 3 {
+	fmStr, bodyStr, ok := splitFrontmatter(content)
+	if !ok {
 		return nil, content, nil
 	}
 
-	fmStr := strings.TrimSpace(parts[1])
-	bodyStr := strings.TrimSpace(parts[2])
+	fmStr = strings.TrimSpace(fmStr)
+	bodyStr = strings.TrimSpace(bodyStr)
 
 	if fmStr == "" {
 		return nil, bodyStr, nil
@@ -260,7 +287,7 @@ func (r *SkillRegistry) BuildL1Block() string {
 
 		line := fmt.Sprintf(
 			"  <skill loaded=\"%v\">\n    <name>%s%s</name>\n    <description>%s</description>\n    <location>%s</location>\n  </skill>\n",
-			s.Loaded, s.Name, marker, html.EscapeString(desc), s.FilePath)
+			s.Loaded, s.Name, marker, html.EscapeString(desc), html.EscapeString(s.FilePath))
 
 		if buf.Len()+len(line) > maxChars {
 			buf.WriteString("  <!-- remaining skills omitted due to L1 budget -->\n")

--- a/internal/skill_registry.go
+++ b/internal/skill_registry.go
@@ -33,10 +33,10 @@ type Skill struct {
 
 // SkillRegistry manages discovery, storage, and lazy loading of skills.
 type SkillRegistry struct {
-	Skills    map[string]*Skill       // keyed by name
-	Config    *config.SkillsConfig    // pointer to config for budget enforcement
-	L1Block   string                  // pre-rendered <available_skills> XML block
-	UsedChars int                     // aggregate chars of currently loaded skills
+	Skills    map[string]*Skill    // keyed by name
+	Config    *config.SkillsConfig // pointer to config for budget enforcement
+	L1Block   string               // pre-rendered <available_skills> XML block
+	UsedChars int                  // aggregate chars of currently loaded skills
 }
 
 // ============================================================================
@@ -49,10 +49,10 @@ const (
 )
 
 const (
-	DefaultMaxL1Chars    = 8000
-	DefaultMaxLoadedChars = 32000
-	DefaultMaxSkillChars  = 20000
-	DefaultTruncateDescAt = 200
+	DefaultMaxL1Chars      = 8000
+	DefaultMaxLoadedChars  = 32000
+	DefaultMaxSkillChars   = 20000
+	DefaultTruncateDescAt  = 200
 	DefaultAutoMatchThresh = 0.1
 )
 

--- a/internal/skill_registry.go
+++ b/internal/skill_registry.go
@@ -162,6 +162,11 @@ func InitSkills(sc *config.SkillsConfig) (*SkillRegistry, error) {
 		Skills: make(map[string]*Skill),
 		Config: sc,
 	}
+	reg.L1Block = reg.BuildL1Block()
+
+	if sc != nil && !sc.AutoScan {
+		return reg, nil
+	}
 
 	skillsDir := resolveSkillsDir()
 	entries, err := os.ReadDir(skillsDir)
@@ -383,9 +388,10 @@ func (r *SkillRegistry) Load(name string) error {
 
 	bodyChars := len(content)
 
-	// Per-skill cap.
+	// Per-skill cap. A configured value of 0 means unlimited; the 1MB
+	// SKILL.md hard cap above still applies.
 	maxSkill := r.budgetMaxSkill()
-	if bodyChars > maxSkill {
+	if maxSkill > 0 && bodyChars > maxSkill {
 		content = content[:maxSkill] + "\n\n...[skill body truncated]"
 		bodyChars = maxSkill
 	}
@@ -551,7 +557,13 @@ func (r *SkillRegistry) budgetMaxLoaded() int {
 }
 
 func (r *SkillRegistry) budgetMaxSkill() int {
-	if r.Config == nil || r.Config.MaxSkillChars <= 0 {
+	if r.Config == nil {
+		return DefaultMaxSkillChars
+	}
+	if r.Config.MaxSkillChars == 0 {
+		return 0
+	}
+	if r.Config.MaxSkillChars < 0 {
 		return DefaultMaxSkillChars
 	}
 	return r.Config.MaxSkillChars

--- a/internal/skill_registry_test.go
+++ b/internal/skill_registry_test.go
@@ -45,6 +45,13 @@ func TestParseSKILL_FrontmatterValid(t *testing.T) {
 			wantDisable: false,
 		},
 		{
+			name:        "YAML value containing dashes",
+			input:       "---\nname: dash-in-value\ndescription: \"Setup --- and teardown\"\n---\nBody content\n",
+			wantName:    "dash-in-value",
+			wantDesc:    "Setup --- and teardown",
+			wantDisable: false,
+		},
+		{
 			name:        "multi-line description",
 			input:       "---\nname: multi-desc\ndescription: |\n  Line one\n  Line two\n---\nBody content\n",
 			wantName:    "multi-desc",

--- a/internal/skill_registry_test.go
+++ b/internal/skill_registry_test.go
@@ -380,6 +380,49 @@ func TestLoadBudgetEnforcement(t *testing.T) {
 	}
 }
 
+func TestLoadMaxSkillCharsZeroMeansUnlimited(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "unlimited-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	const bodyLen = DefaultMaxSkillChars + 500
+	bodyContent := strings.Repeat("x", bodyLen)
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	skillContent := "---\nname: unlimited-skill\ndescription: Per-skill cap disabled\n---\n" + bodyContent
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &SkillRegistry{
+		Skills: map[string]*Skill{
+			"unlimited-skill": {
+				Name:        "unlimited-skill",
+				Description: "Per-skill cap disabled",
+				DirPath:     skillDir,
+				FilePath:    skillFile,
+			},
+		},
+		Config: &config.SkillsConfig{
+			MaxLoadedChars: bodyLen + 1000,
+			MaxSkillChars:  0,
+		},
+	}
+
+	if err := reg.Load("unlimited-skill"); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	loaded := reg.Skills["unlimited-skill"]
+	if loaded.BodyLength != bodyLen {
+		t.Fatalf("BodyLength = %d, want %d", loaded.BodyLength, bodyLen)
+	}
+	if strings.Contains(loaded.Body, "...[skill body truncated]") {
+		t.Fatal("max_skill_chars: 0 should not truncate skill body")
+	}
+}
+
 // =====================================================================
 // TestLoadIdempotent
 // =====================================================================
@@ -765,6 +808,7 @@ func TestValidateDiscoverAndCapErrors(t *testing.T) {
 			t.Cleanup(func() { os.Setenv("HOME", origHome) })
 
 			sc := &config.SkillsConfig{
+				AutoScan:           true,
 				MaxL1Chars:         8000,
 				MaxLoadedChars:     32000,
 				MaxSkillChars:      20000,
@@ -810,6 +854,37 @@ func TestValidateDiscoverAndCapErrors(t *testing.T) {
 				t.Error("L1Block should not be empty")
 			}
 		})
+	}
+}
+
+func TestInitSkillsHonorsAutoScanFalse(t *testing.T) {
+	baseTemp := t.TempDir()
+	configDir := filepath.Join(baseTemp, ".config", "tmuxai")
+	skillsDir := filepath.Join(configDir, "skills")
+	skillDir := filepath.Join(skillsDir, "valid-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillContent := "---\nname: valid-skill\ndescription: A valid skill that should not be scanned\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", baseTemp)
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+
+	reg, err := InitSkills(&config.SkillsConfig{
+		AutoScan:       false,
+		MaxL1Chars:     8000,
+		MaxLoadedChars: 32000,
+		MaxSkillChars:  20000,
+	})
+	if err != nil {
+		t.Fatalf("InitSkills returned error: %v", err)
+	}
+	if len(reg.Skills) != 0 {
+		t.Fatalf("AutoScan false discovered skills: %v", skillNames(reg))
 	}
 }
 

--- a/internal/skill_registry_test.go
+++ b/internal/skill_registry_test.go
@@ -1,0 +1,817 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/alvinunreal/tmuxai/config"
+)
+
+// =====================================================================
+// TestParseSKILL_FrontmatterValid
+// =====================================================================
+
+func TestParseSKILL_FrontmatterValid(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantDesc    string
+		wantDisable bool
+	}{
+		{
+			name:        "basic frontmatter",
+			input:       "---\nname: hello-world\ndescription: Says hello\ndisable-model-invocation: false\n---\n# Hello World Skill\n\nThis skill prints hello.\n",
+			wantName:    "hello-world",
+			wantDesc:    "Says hello",
+			wantDisable: false,
+		},
+		{
+			name:        "disabled skill",
+			input:       "---\nname: manual-mode\ndescription: Manual only\ndisable-model-invocation: true\n---\nManual content here\n",
+			wantName:    "manual-mode",
+			wantDesc:    "Manual only",
+			wantDisable: true,
+		},
+		{
+			name:        "extra frontmatter fields ignored",
+			input:       "---\nname: extra-fields\ndescription: Has extras\nauthor: test\nversion: 1.0\n---\nExtra body\n",
+			wantName:    "extra-fields",
+			wantDesc:    "Has extras",
+			wantDisable: false,
+		},
+		{
+			name:        "multi-line description",
+			input:       "---\nname: multi-desc\ndescription: |\n  Line one\n  Line two\n---\nBody content\n",
+			wantName:    "multi-desc",
+			wantDesc:    "Line one\nLine two",
+			wantDisable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta, body, err := ParseSkillMd([]byte(tc.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if meta == nil {
+				t.Fatal("expected frontmatter meta, got nil")
+			}
+			extractedName, extractedDesc, extractedDisabled := extractSkillMeta(meta)
+			if extractedName != tc.wantName {
+				t.Errorf("name: got %q, want %q", extractedName, tc.wantName)
+			}
+			if extractedDesc != tc.wantDesc {
+				t.Errorf("description: got %q, want %q", extractedDesc, tc.wantDesc)
+			}
+			if extractedDisabled != tc.wantDisable {
+				t.Errorf("disabled: got %v, want %v", extractedDisabled, tc.wantDisable)
+			}
+			if body == "" {
+				t.Error("expected non-empty body")
+			}
+		})
+	}
+}
+
+// =====================================================================
+// TestParseSKILL_FrontmatterMalformed
+// =====================================================================
+
+func TestParseSKILL_FrontmatterMalformed(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               string
+		expectNoFrontmatter bool // nil meta means treated-as-no-frontmatter (graceful)
+		expectError         bool
+		wantEmptyDesc       bool
+	}{
+		{
+			name:                "missing frontmatter entirely",
+			input:               "# Just a regular SKILL.md\nNo frontmatter here.\n",
+			expectNoFrontmatter: true,
+		},
+		{
+			name:                "empty description",
+			input:               "---\nname: empty-desc\n---\nBody content\n",
+			expectNoFrontmatter: false,
+			wantEmptyDesc:       true,
+		},
+		{
+			name:                "truncated opening delimiter",
+			input:               "--\nname: trunc-open\ndescription: truncated\n---\nBody\n",
+			expectNoFrontmatter: true,
+		},
+		{
+			name:                "no closing delimiter",
+			input:               "---\nname: no-close\ndescription: never closes\nJust runs forever...\n",
+			expectNoFrontmatter: false,
+		},
+		{
+			name:        "malformed YAML frontmatter",
+			input:       "---\nname: broken-yaml\ndescription: [\ninvalid: {\n---\nBody\n",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Ensure no panic occurs
+			meta, body, err := ParseSkillMd([]byte(tc.input))
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error for malformed YAML, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.expectNoFrontmatter && meta != nil {
+				t.Error("expected nil meta (no frontmatter), got non-nil")
+			}
+
+			// Extract with nil-safe function (should not panic)
+			name, desc, _ := extractSkillMeta(meta)
+			if tc.expectNoFrontmatter && name != "" {
+				t.Logf("graceful degradation: name=%q body_len=%d", name, len(body))
+			}
+			if tc.wantEmptyDesc && desc != "" {
+				t.Errorf("wanted empty description, got %q", desc)
+			}
+
+			// Body should contain something reasonable
+			if !tc.expectNoFrontmatter && body == "" {
+				t.Error("expected non-empty body for non-YAML-error case")
+			}
+		})
+	}
+}
+
+// =====================================================================
+// TestAutoMatchScoresThreshold
+// =====================================================================
+
+func TestAutoMatchScoresThreshold(t *testing.T) {
+	sc := &config.SkillsConfig{
+		AutoMatchThreshold: 0.1,
+		MaxLoadedChars:     32000,
+	}
+
+	buildReg := func(t *testing.T, skills map[string]string) *SkillRegistry {
+		t.Helper()
+		reg := &SkillRegistry{
+			Skills: make(map[string]*Skill),
+			Config: sc,
+		}
+		for name, desc := range skills {
+			reg.Skills[name] = &Skill{
+				Name:        name,
+				Description: desc,
+				Disabled:    false,
+				Loaded:      false,
+			}
+		}
+		return reg
+	}
+
+	tests := []struct {
+		name         string
+		skills       map[string]string
+		context      string
+		setLoaded    bool // if true, marks the first skill as loaded
+		setDisabled  bool // if true, marks the second skill as disabled
+		wantContains []string
+		wantMissing  []string
+	}{
+		{
+			name: "matching keyword hits threshold",
+			skills: map[string]string{
+				"python-debugging": "Python debugger pdb trace breakpoint stack inspection debugging",
+				"go-formatting":    "Go formatter golint staticcheck linting formatting",
+			},
+			context:      "I need to debug this python script with pdb traceback",
+			wantContains: []string{"python-debugging"},
+			wantMissing:  []string{"go-formatting"},
+		},
+		{
+			name: "no relevant skills",
+			skills: map[string]string{
+				"python-debugging": "Python debugger pdb trace breakpoint stack inspection debugging",
+				"go-formatting":    "Go formatter golint staticcheck linting formatting",
+			},
+			context:     "deploy kubernetes pod namespace cluster",
+			wantMissing: []string{"python-debugging", "go-formatting"},
+		},
+		{
+			name: "disabled skill excluded",
+			skills: map[string]string{
+				"active-skill":   "test keyword alpha beta gamma",
+				"disabled-skill": "test keyword alpha beta gamma",
+			},
+			context:      "keyword alpha beta gamma test",
+			setDisabled:  true,
+			wantContains: []string{"active-skill"},
+			wantMissing:  []string{"disabled-skill"},
+		},
+		{
+			name: "loaded skill excluded",
+			skills: map[string]string{
+				"already-loaded": "keyword alpha beta gamma important",
+				"unloaded-skill": "different distinct unique term rare",
+			},
+			context:     "important keyword alpha beta gamma",
+			setLoaded:   true,
+			wantMissing: []string{"already-loaded"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := buildReg(t, tc.skills)
+
+			// Apply modifier flags
+			skillList := make([]*Skill, 0, len(reg.Skills))
+			for _, s := range reg.Skills {
+				skillList = append(skillList, s)
+			}
+			sort.Slice(skillList, func(i, j int) bool {
+				return skillList[i].Name < skillList[j].Name
+			})
+
+			if tc.setLoaded && len(skillList) > 0 {
+				skillList[0].Loaded = true
+			}
+			if tc.setDisabled && len(skillList) > 1 {
+				skillList[1].Disabled = true
+			}
+
+			results := reg.AutoMatch(tc.context)
+			resultNames := make(map[string]bool)
+			for _, s := range results {
+				resultNames[s.Name] = true
+			}
+
+			for _, want := range tc.wantContains {
+				if !resultNames[want] {
+					t.Errorf("expected %q in results, got %v", want, resultNames)
+				}
+			}
+			for _, miss := range tc.wantMissing {
+				if resultNames[miss] {
+					t.Errorf("did not expect %q in results, but it appeared", miss)
+				}
+			}
+		})
+	}
+}
+
+// =====================================================================
+// TestLoadBudgetEnforcement
+// =====================================================================
+
+func TestLoadBudgetEnforcement(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "large-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	const bodyLen = 5000
+	largeBody := strings.Repeat("a", bodyLen)
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	skillContent := "---\nname: large-skill\ndescription: A skill with a huge body\n---\n" + largeBody
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, parsedBody, err := ParseSkillMd([]byte(skillContent))
+	if err != nil {
+		t.Fatalf("ParseSkillMd: %v", err)
+	}
+	bodyChars := len(parsedBody)
+
+	tests := []struct {
+		name             string
+		maxLoaded        int
+		usedChars        int
+		wantErr          bool
+		wantSkillLoaded  bool
+		wantUsedCharsGEQ int
+	}{
+		{
+			name:            "budget exceeded – no prior usage",
+			maxLoaded:       bodyChars - 100,
+			usedChars:       0,
+			wantErr:         true,
+			wantSkillLoaded: false,
+		},
+		{
+			name:            "budget exceeded – with prior usage",
+			maxLoaded:       bodyChars + 300,
+			usedChars:       400,
+			wantErr:         true, // 400 + bodyChars > bodyChars + 500 ? 400+5000 > 5500 => true
+			wantSkillLoaded: false,
+		},
+		{
+			name:             "within budget – no prior usage",
+			maxLoaded:        bodyChars + 1000,
+			usedChars:        0,
+			wantSkillLoaded:  true,
+			wantUsedCharsGEQ: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := &SkillRegistry{
+				Skills: map[string]*Skill{
+					"large-skill": {
+						Name:        "large-skill",
+						Description: "A skill with a huge body",
+						DirPath:     skillDir,
+						FilePath:    skillFile,
+						BodyLength:  bodyChars,
+					},
+				},
+				Config: &config.SkillsConfig{
+					MaxLoadedChars: tc.maxLoaded,
+					MaxSkillChars:  20000,
+				},
+			}
+			reg.UsedChars = tc.usedChars
+
+			err := reg.Load("large-skill")
+
+			if tc.wantErr && err == nil {
+				t.Error("expected error due to budget exceeded, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+
+			if reg.Skills["large-skill"].Loaded != tc.wantSkillLoaded {
+				t.Errorf("Loaded = %v, want %v", reg.Skills["large-skill"].Loaded, tc.wantSkillLoaded)
+			}
+
+			if !tc.wantSkillLoaded && reg.UsedChars != tc.usedChars {
+				t.Errorf("UsedChars changed from %d to %d on failed load", tc.usedChars, reg.UsedChars)
+			}
+
+			if tc.wantSkillLoaded && reg.UsedChars < tc.wantUsedCharsGEQ {
+				t.Errorf("UsedChars = %d, want >= %d", reg.UsedChars, tc.wantUsedCharsGEQ)
+			}
+		})
+	}
+}
+
+// =====================================================================
+// TestLoadIdempotent
+// =====================================================================
+
+func TestLoadIdempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "idem-skill")
+	os.MkdirAll(skillDir, 0755)
+
+	bodyContent := strings.Repeat("x", 500)
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	skillContent := "---\nname: idem-skill\ndescription: Idempotent load test\n---\n" + bodyContent
+	os.WriteFile(skillFile, []byte(skillContent), 0644)
+
+	reg := &SkillRegistry{
+		Skills: map[string]*Skill{
+			"idem-skill": {
+				Name:        "idem-skill",
+				Description: "Idempotent load test",
+				DirPath:     skillDir,
+				FilePath:    skillFile,
+			},
+		},
+		Config: &config.SkillsConfig{
+			MaxLoadedChars: 10000,
+			MaxSkillChars:  20000,
+		},
+	}
+
+	// First load
+	if err := reg.Load("idem-skill"); err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+	firstUsed := reg.UsedChars
+	if !reg.Skills["idem-skill"].Loaded {
+		t.Fatal("skill should be loaded after first call")
+	}
+
+	// Second load – must return nil and NOT double-count
+	if err := reg.Load("idem-skill"); err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if reg.UsedChars != firstUsed {
+		t.Errorf("UsedChars changed from %d to %d on idempotent load", firstUsed, reg.UsedChars)
+	}
+}
+
+// =====================================================================
+// TestLoadPerSkillTruncation
+// =====================================================================
+
+func TestLoadPerSkillTruncation(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "huge-skill")
+	os.MkdirAll(skillDir, 0755)
+
+	hugeBody := strings.Repeat("z", 25000) // exceeds DefaultMaxSkillChars (20000)
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	skillContent := "---\nname: huge-skill\ndescription: Huge body\n---\n" + hugeBody
+	os.WriteFile(skillFile, []byte(skillContent), 0644)
+
+	reg := &SkillRegistry{
+		Skills: map[string]*Skill{
+			"huge-skill": {
+				Name:        "huge-skill",
+				Description: "Huge body",
+				DirPath:     skillDir,
+				FilePath:    skillFile,
+			},
+		},
+		Config: &config.SkillsConfig{
+			MaxLoadedChars: 50000,
+			MaxSkillChars:  10000, // enforce smaller cap for test
+		},
+	}
+
+	if err := reg.Load("huge-skill"); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	skill := reg.Skills["huge-skill"]
+	if !skill.Loaded {
+		t.Fatal("skill should be loaded")
+	}
+	if len(skill.Body) > 10000+len("\n\n...[skill body truncated]") {
+		t.Errorf("Body length %d exceeds MaxSkillChars 10000 (+ truncation suffix)", len(skill.Body))
+	}
+	if !strings.Contains(skill.Body, "[skill body truncated]") {
+		t.Error("truncated body should contain truncation marker")
+	}
+}
+
+// =====================================================================
+// TestUnload
+// =====================================================================
+
+func TestUnload(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "unload-me")
+	os.MkdirAll(skillDir, 0755)
+
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	skillContent := "---\nname: unload-me\ndescription: Unload test\n---\nBody text here\n"
+	os.WriteFile(skillFile, []byte(skillContent), 0644)
+
+	reg := &SkillRegistry{
+		Skills: map[string]*Skill{
+			"unload-me": {
+				Name:        "unload-me",
+				Description: "Unload test",
+				DirPath:     skillDir,
+				FilePath:    skillFile,
+			},
+		},
+		Config: &config.SkillsConfig{
+			MaxLoadedChars: 32000,
+			MaxSkillChars:  20000,
+		},
+	}
+
+	// Load first
+	if err := reg.Load("unload-me"); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	preUsed := reg.UsedChars
+	if preUsed <= 0 {
+		t.Fatal("UsedChars should be > 0 after load")
+	}
+
+	// Unload
+	if err := reg.Unload("unload-me"); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	skill := reg.Skills["unload-me"]
+	if skill.Loaded {
+		t.Error("Loaded should be false after unload")
+	}
+	if skill.Body != "" {
+		t.Error("Body should be empty after unload")
+	}
+	if skill.BodyLength != 0 {
+		t.Error("BodyLength should be 0 after unload")
+	}
+	if reg.UsedChars > 0 {
+		t.Errorf("UsedChars should be 0 after unload, got %d", reg.UsedChars)
+	}
+
+	// Double-unload should error
+	if err := reg.Unload("unload-me"); err == nil {
+		t.Error("expected error when unloading non-loaded skill, got nil")
+	}
+
+	// Unload nonexistent skill should error
+	if err := reg.Unload("ghost-skill"); err == nil {
+		t.Error("expected error when unloading nonexistent skill, got nil")
+	}
+}
+
+// =====================================================================
+// TestBuildL1Block
+// =====================================================================
+
+func TestBuildL1Block(t *testing.T) {
+	sc := &config.SkillsConfig{
+		MaxL1Chars:     8000,
+		TruncateDescAt: 50, // short truncate for test
+	}
+	reg := &SkillRegistry{
+		Skills: map[string]*Skill{
+			"aaa-short": {
+				Name:        "aaa-short",
+				Description: "Short desc",
+				FilePath:    "/fake/path/aaa",
+				Loaded:      false,
+			},
+			"bbb-long-desc": {
+				Name:        "bbb-long-desc",
+				Description: "This is a very long description that should be truncated because it exceeds the truncate limit set in config",
+				FilePath:    "/fake/path/bbb",
+				Loaded:      true,
+			},
+			"ccc-disabled": {
+				Name:        "ccc-disabled",
+				Description: "Manual skill",
+				Disabled:    true,
+				FilePath:    "/fake/path/ccc",
+				Loaded:      false,
+			},
+		},
+		Config: sc,
+	}
+
+	block := reg.BuildL1Block()
+
+	// Structure checks
+	if !strings.Contains(block, "<available_skills>") {
+		t.Error("block should contain <available_skills>")
+	}
+	if !strings.Contains(block, "</available_skills>") {
+		t.Error("block should contain </available_skills>")
+	}
+
+	// Sorting: aaa before bbb before ccc
+	aaaPos := strings.Index(block, "aaa-short")
+	bbbPos := strings.Index(block, "bbb-long-desc")
+	cccPos := strings.Index(block, "ccc-disabled")
+	if aaaPos >= bbbPos || bbbPos >= cccPos || cccPos < 0 {
+		t.Logf("positions: aaa=%d bbb=%d ccc=%d", aaaPos, bbbPos, cccPos)
+		t.Error("skills should be sorted alphabetically")
+	}
+
+	// Disabled marker
+	if !strings.Contains(block, "[manual]") {
+		t.Error("disabled skill should have [manual] marker")
+	}
+
+	// Loaded attribute on bbb
+	if !strings.Contains(block, `loaded="true"`) {
+		t.Error("bbb should have loaded=\"true\"")
+	}
+
+	// Description truncation on bbb
+	if strings.Contains(block, "very long description that should be truncated because it exceeds") {
+		t.Error("bbb description should be truncated")
+	}
+}
+
+// =====================================================================
+// TestBuildL1BlockBudgetCutoff
+// =====================================================================
+
+func TestBuildL1BlockBudgetCutoff(t *testing.T) {
+	// Tiny budget to force early cutoff
+	sc := &config.SkillsConfig{
+		MaxL1Chars:     200, // very small
+		TruncateDescAt: 200,
+	}
+	reg := &SkillRegistry{
+		Skills: make(map[string]*Skill),
+		Config: sc,
+	}
+	// Add 10 skills with descriptive names to exhaust budget
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("skill-%02d-with-long-name", i)
+		reg.Skills[name] = &Skill{
+			Name:        name,
+			Description: fmt.Sprintf("Description for skill number %d with lots of text", i),
+			FilePath:    "/fake/path",
+		}
+	}
+
+	block := reg.BuildL1Block()
+	if !strings.Contains(block, "remaining skills omitted") {
+		t.Error("tiny budget should trigger budget cutoff comment")
+	}
+}
+
+// =====================================================================
+// TestBuildManifest
+// =====================================================================
+
+func TestBuildManifest(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Skill dir with ancillary files
+	skillDir := filepath.Join(tempDir, "my-skill")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\ndescription: test\n---\nBody\n"), 0644)
+	os.WriteFile(filepath.Join(skillDir, "helper.sh"), []byte("#!/bin/bash\necho hi"), 0644)
+	os.WriteFile(filepath.Join(skillDir, "README.md"), []byte("# Helper docs"), 0644)
+
+	subDir := filepath.Join(skillDir, "snippets")
+	os.MkdirAll(subDir, 0755)
+	os.WriteFile(filepath.Join(subDir, "snippet1.txt"), []byte("snippet content"), 0644)
+
+	skill := &Skill{Name: "my-skill", DirPath: skillDir}
+
+	// Normal manifest
+	manifest := skill.BuildManifest()
+	if !strings.Contains(manifest, "Skill File Manifest") {
+		t.Error("manifest should contain header")
+	}
+	if !strings.Contains(manifest, "helper.sh") {
+		t.Error("manifest should list helper.sh")
+	}
+	if !strings.Contains(manifest, "README.md") {
+		t.Error("manifest should list README.md")
+	}
+	if strings.Contains(manifest, "SKILL.md") {
+		t.Error("manifest should NOT list SKILL.md")
+	}
+
+	// No ancillary files
+	emptyDir := filepath.Join(tempDir, "bare-skill")
+	os.MkdirAll(emptyDir, 0755)
+	os.WriteFile(filepath.Join(emptyDir, "SKILL.md"), []byte("---\nname: bare-skill\ndescription: bare\n---\nBody\n"), 0644)
+	bareSkill := &Skill{Name: "bare-skill", DirPath: emptyDir}
+	emptyManifest := bareSkill.BuildManifest()
+	if emptyManifest != "" {
+		t.Error("bare skill should return empty manifest")
+	}
+}
+
+// =====================================================================
+// TestBuildManifestFileCap
+// =====================================================================
+
+func TestBuildManifestFileCap(t *testing.T) {
+	tempDir := t.TempDir()
+	skillDir := filepath.Join(tempDir, "many-files")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: many-files\ndescription: many\n---\nBody\n"), 0644)
+
+	// Create more files than maxManifestFiles (100)
+	for i := 0; i < 110; i++ {
+		fn := fmt.Sprintf("file_%04d.txt", i)
+		os.WriteFile(filepath.Join(skillDir, fn), []byte("content"), 0644)
+	}
+
+	skill := &Skill{Name: "many-files", DirPath: skillDir}
+	manifest := skill.BuildManifest()
+	if !strings.Contains(manifest, "manifest truncated") {
+		t.Error("manifest should be truncated when exceeding file cap")
+	}
+}
+
+// =====================================================================
+// TestValidateDiscoverAndCapErrors (via InitSkills)
+// =====================================================================
+
+func TestValidateDiscoverAndCapErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupFunc    func(baseTemp string)
+		wantFound    map[string]bool
+		wantNotFound []string
+	}{
+		{
+			name: "discovers valid, skips corrupted",
+			setupFunc: func(base string) {
+				configDir := filepath.Join(base, ".config", "tmuxai")
+				skillsDir := filepath.Join(configDir, "skills")
+
+				// Valid skill
+				validDir := filepath.Join(skillsDir, "valid-skill")
+				os.MkdirAll(validDir, 0755)
+				validContent := "---\nname: valid-skill\ndescription: A perfectly valid skill for testing\n---\nSome useful content here.\n"
+				os.WriteFile(filepath.Join(validDir, "SKILL.md"), []byte(validContent), 0644)
+
+				// Corrupted skill: YAML error
+				corrDir := filepath.Join(skillsDir, "corrupt-yaml")
+				os.MkdirAll(corrDir, 0755)
+				corrContent := "---\nname: corrupt-yaml\ndescription: [{bad yaml\n---\nBody\n"
+				os.WriteFile(filepath.Join(corrDir, "SKILL.md"), []byte(corrContent), 0644)
+
+				// Invalid name skill: uppercase letters
+				badNameDir := filepath.Join(skillsDir, "Bad-Name")
+				os.MkdirAll(badNameDir, 0755)
+				badNameContent := "---\nname: Bad-Name\ndescription: Has uppercase name\n---\nBody\n"
+				os.WriteFile(filepath.Join(badNameDir, "SKILL.md"), []byte(badNameContent), 0644)
+
+				// Missing name/description
+				noNameDir := filepath.Join(skillsDir, "no-name")
+				os.MkdirAll(noNameDir, 0755)
+				noNameContent := "---\ndescription: No name provided\n---\nBody\n"
+				os.WriteFile(filepath.Join(noNameDir, "SKILL.md"), []byte(noNameContent), 0644)
+
+				// Empty directory (no SKILL.md)
+				emptyDir := filepath.Join(skillsDir, "empty-dir")
+				os.MkdirAll(emptyDir, 0755)
+			},
+			wantFound:    map[string]bool{"valid-skill": true},
+			wantNotFound: []string{"corrupt-yaml", "Bad-Name", "no-name", "empty-dir"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseTemp := t.TempDir()
+			tc.setupFunc(baseTemp)
+
+			origHome := os.Getenv("HOME")
+			os.Setenv("HOME", baseTemp)
+			t.Cleanup(func() { os.Setenv("HOME", origHome) })
+
+			sc := &config.SkillsConfig{
+				MaxL1Chars:         8000,
+				MaxLoadedChars:     32000,
+				MaxSkillChars:      20000,
+				TruncateDescAt:     200,
+				AutoMatchThreshold: 0.1,
+			}
+
+			reg, err := InitSkills(sc)
+			if err != nil {
+				t.Fatalf("InitSkills returned error: %v", err)
+			}
+
+			// Check wanted skills are found
+			for wantName := range tc.wantFound {
+				if _, ok := reg.Skills[wantName]; !ok {
+					t.Errorf("expected skill %q to be discovered, got skills: %v",
+						wantName, skillNames(reg))
+				}
+			}
+
+			// Check unwanted skills are not found
+			for _, notWant := range tc.wantNotFound {
+				if _, ok := reg.Skills[notWant]; ok {
+					t.Errorf("expected skill %q NOT to be discovered, but it was", notWant)
+				}
+			}
+
+			// Valid skill attributes
+			if s, ok := reg.Skills["valid-skill"]; ok {
+				if s.Description != "A perfectly valid skill for testing" {
+					t.Errorf("description: got %q, want %q", s.Description, "A perfectly valid skill for testing")
+				}
+				if s.Loaded {
+					t.Error("skill should not be pre-loaded by InitSkills")
+				}
+				if s.FilePath == "" {
+					t.Error("FilePath should be populated")
+				}
+			}
+
+			// L1Block should be generated (non-empty)
+			if reg.L1Block == "" {
+				t.Error("L1Block should not be empty")
+			}
+		})
+	}
+}
+
+// skillNames returns sorted skill names from a registry.
+func skillNames(r *SkillRegistry) []string {
+	names := make([]string, 0, len(r.Skills))
+	for n := range r.Skills {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/skill_registry_test.go
+++ b/internal/skill_registry_test.go
@@ -836,6 +836,22 @@ func TestValidateDiscoverAndCapErrors(t *testing.T) {
 				}
 			}
 
+			if len(reg.DiscoveryWarnings) != len(tc.wantNotFound) {
+				t.Errorf("DiscoveryWarnings length = %d, want %d: %v", len(reg.DiscoveryWarnings), len(tc.wantNotFound), reg.DiscoveryWarnings)
+			}
+			for _, notWant := range tc.wantNotFound {
+				foundWarning := false
+				for _, warning := range reg.DiscoveryWarnings {
+					if strings.HasPrefix(warning, notWant+":") {
+						foundWarning = true
+						break
+					}
+				}
+				if !foundWarning {
+					t.Errorf("expected discovery warning for %q, got %v", notWant, reg.DiscoveryWarnings)
+				}
+			}
+
 			// Valid skill attributes
 			if s, ok := reg.Skills["valid-skill"]; ok {
 				if s.Description != "A perfectly valid skill for testing" {
@@ -885,6 +901,9 @@ func TestInitSkillsHonorsAutoScanFalse(t *testing.T) {
 	}
 	if len(reg.Skills) != 0 {
 		t.Fatalf("AutoScan false discovered skills: %v", skillNames(reg))
+	}
+	if len(reg.DiscoveryWarnings) != 0 {
+		t.Fatalf("AutoScan false should not validate skills, got warnings: %v", reg.DiscoveryWarnings)
 	}
 }
 

--- a/internal/squash.go
+++ b/internal/squash.go
@@ -18,6 +18,11 @@ func (m *Manager) needSquash() bool {
 	totalTokens += system.EstimateTokenCount(m.chatAssistantPrompt(isPrepared).Content)
 	totalTokens += m.getTotalLoadedKBTokens()
 
+	// Count loaded skill content toward squash budget.
+	for _, content := range m.LoadedSkills {
+		totalTokens += system.EstimateTokenCount(content)
+	}
+
 	for _, msg := range m.Messages {
 		totalTokens += system.EstimateTokenCount(msg.Content)
 	}


### PR DESCRIPTION
I've been loving using tmuxai. One thing I wish i had that makes tmuxai more powerful is adaption of the common SKILLS.md system. It's mature enough with standards to be able to empower tmuxai more so than the current /KB system. There is a plethora of SKILLS in the wild that can be plug and play for shell type activities. This PR is fairly lightweight and adds an optional SKILLS system that default to disabled.

## Feature: SKILL.md Loading System

Adds a modular skills context-loading system to TmuxAI, inspired by the existing
knowledge base (KB) architecture.

### What it does
- Parses SKILL.md files (YAML frontmatter + Markdown body)
- L1 registry with char-based context budget enforcement
- TF-IDF auto-match: skills load automatically when conversation matches description
- `/skill load`, `/skill list`, `/skill unload` commands

### Details
- Similar code path to existing KB system for familiarity
- 12 test functions, race-clean
- Config-driven (opt-out/auto-scan thresholds)
- No model invocation required — pure deterministic parsing + matching

### Testing
- Built and tested locally against upstream main
- `go vet` / `go test -race` pass clean
- Smoke-tested interactively in tmux session

### New config options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `knowledge_base.skills.enabled` | `bool` | `false` | Master enable/disable for the skills system |
| `knowledge_base.skills.auto_scan` | `bool` | `true` | Scan `~/.config/tmuxai/skills/` for `SKILL.md` on startup |
| `knowledge_base.skills.auto_match` | `bool` | `false` | Enable TF-IDF auto-match of skills to conversation |
| `knowledge_base.skills.auto_match_threshold` | `float64` | `0.1` | Min TF-IDF score (0.0–1.0) to trigger auto-match |
| `knowledge_base.skills.max_l1_chars` | `int` | `8000` | Char budget for L1 summary (names + descriptions) |
| `knowledge_base.skills.max_loaded_chars` | `int` | `32000` | Total char budget for fully loaded skill bodies |
| `knowledge_base.skills.max_skill_chars` | `int` | `20000` | Max size of individual `SKILL.md` file |
| `knowledge_base.skills.truncate_desc_at` | `int` | `200` | Truncate L1 descriptions beyond this length |

```yaml
# Example config.yaml
knowledge_base:
  auto_load: []
  path: ""
  skills:
    enabled: true
    auto_scan: true
    auto_match: true
    auto_match_threshold: 0.05
    max_l1_chars: 8000
    max_loaded_chars: 32000