### PR TITLE
Add customizable prompt status

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [Core Commands](#core-commands)
 - [Command-Line Usage](#command-line-usage)
 - [Configuration](#configuration)
+  - [Prompt Customization](#prompt-customization)
   - [Environment Variables](#environment-variables)
   - [Session-Specific Configuration](#session-specific-configuration)
 - [Contributing](#contributing)
@@ -912,6 +913,41 @@ tmux split-window <exec_split_args...> -t <target> -P -F "#{pane_id}"
 Reserved flags `-t`, `-P`, and `-F` are managed internally and must not be included in `exec_split_args`.
 
 If omitted, TmuxAI uses the legacy default: `-d -h`.
+
+### Prompt Customization
+
+By default, the chat prompt stays compact and shows status only when needed, such as the active non-default model or watch/running state. You can fully customize it with `prompts.prompt`:
+
+```yaml
+prompts:
+  # Empty preserves the default prompt.
+  prompt: "{app} ({context}/{max_context}) - {model} » "
+```
+
+Supported placeholders:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{app}` | TmuxAI app label |
+| `{model}` | Current selected model configuration name, or legacy model name |
+| `{state}` | Current state symbol, such as running, waiting, done, or watch mode |
+| `{context}` | Approximate current message context size, compact formatted |
+| `{max_context}` | Configured maximum context size, compact formatted |
+| `{context_percent}` | Approximate message context usage percentage |
+
+Examples:
+
+```yaml
+prompts:
+  prompt: "✨ "
+```
+
+```yaml
+prompts:
+  prompt: "{app} ({context}/{max_context}) - {model} » "
+```
+
+Context values use the same approximate message-token counting logic shown by `/info` and are formatted for prompt width, for example `37k/256k`.
 
 ### Web Search & Fetch Configuration
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -129,6 +129,14 @@ knowledge_base:
 
 # Prompts customization, see prompts.go for more details
 prompts:
+  # Interactive prompt template. Empty preserves the default prompt.
+  # Supported placeholders: {app}, {model}, {state}, {context}, {max_context}, {context_percent}
+  # Context values use the same approximate message-token count shown by /info.
+  # Examples:
+  #   prompt: "✨ "
+  #   prompt: "{app} ({context}/{max_context}) - {model} » "
+  prompt: ""
+
   base_system: |
     xxx
 

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type PromptsConfig struct {
 	ChatAssistant         string `mapstructure:"chat_assistant"`
 	ChatAssistantPrepared string `mapstructure:"chat_assistant_prepared"`
 	Watch                 string `mapstructure:"watch"`
+	Prompt                string `mapstructure:"prompt"`
 }
 
 // SkillsConfig holds skill system configuration

--- a/internal/config_helpers.go
+++ b/internal/config_helpers.go
@@ -26,6 +26,7 @@ var AllowedConfigKeys = []string{
 	"azure_openai.api_base",
 	"azure_openai.api_version",
 	"default_model",
+	"prompts.prompt",
 }
 
 // GetMaxCaptureLines returns the max capture lines value with session override if present

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -166,6 +166,13 @@ func (m *Manager) GetConfig() *config.Config {
 
 // getPrompt returns the prompt string with color
 func (m *Manager) GetPrompt() string {
+	// Check if custom prompt template is configured
+	customPrompt := m.getCustomPromptTemplate()
+	if customPrompt != "" {
+		return m.renderPromptTemplate(customPrompt)
+	}
+
+	// Default prompt behavior (backward compatible)
 	tmuxaiColor := color.New(color.FgGreen, color.Bold)
 	arrowColor := color.New(color.FgYellow, color.Bold)
 	stateColor := color.New(color.FgMagenta, color.Bold)
@@ -209,6 +216,113 @@ func (m *Manager) GetPrompt() string {
 	}
 	prompt += arrowColor.Sprint(" » ")
 	return prompt
+}
+
+// getCustomPromptTemplate returns the custom prompt template if configured
+func (m *Manager) getCustomPromptTemplate() string {
+	// Check session override first
+	if override, exists := m.SessionOverrides["prompts.prompt"]; exists {
+		if val, ok := override.(string); ok {
+			return val
+		}
+	}
+	return m.Config.Prompts.Prompt
+}
+
+// getCurrentContextSize calculates the total token count of all messages
+func (m *Manager) getCurrentContextSize() int {
+	var totalTokens int
+	for _, msg := range m.Messages {
+		totalTokens += system.EstimateTokenCount(msg.Content)
+	}
+	return totalTokens
+}
+
+// formatCompactNumber formats a number in compact form (e.g., 37000 -> 37k)
+func formatCompactNumber(n int) string {
+	if n >= 1000000 {
+		return fmt.Sprintf("%.1fm", float64(n)/1000000)
+	}
+	if n >= 1000 {
+		return fmt.Sprintf("%dk", n/1000)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// getModelLabel returns the current model label for display
+func (m *Manager) getModelLabel() string {
+	currentModel := m.GetModelsDefault()
+	if currentModel != "" {
+		return currentModel
+	}
+
+	// Fallback to legacy model name
+	if modelConfig, exists := m.GetCurrentModelConfig(); exists {
+		return modelConfig.Model
+	}
+	return "unknown"
+}
+
+// renderPromptTemplate renders a prompt template with placeholders
+func (m *Manager) renderPromptTemplate(template string) string {
+	// Define colors
+	tmuxaiColor := color.New(color.FgGreen, color.Bold)
+	modelColor := color.New(color.FgCyan, color.Bold)
+	stateColor := color.New(color.FgMagenta, color.Bold)
+	contextColor := color.New(color.FgWhite)
+	maxContextColor := color.New(color.FgWhite)
+	percentColor := color.New(color.FgWhite)
+
+	// Get state symbol
+	var stateSymbol string
+	switch m.Status {
+	case "running":
+		stateSymbol = "▶"
+	case "waiting":
+		stateSymbol = "?"
+	case "done":
+		stateSymbol = "✓"
+	default:
+		stateSymbol = ""
+	}
+	if m.WatchMode {
+		stateSymbol = "∞"
+	}
+
+	// Calculate context info only when the template needs it. Prompt rendering can
+	// happen frequently, and scanning all messages is unnecessary for compact
+	// prompts such as "✨ ".
+	contextSize := 0
+	maxContext := 0
+	contextPercent := 0.0
+	needsContext := strings.Contains(template, "{context}") ||
+		strings.Contains(template, "{max_context}") ||
+		strings.Contains(template, "{context_percent}")
+	if needsContext {
+		contextSize = m.getCurrentContextSize()
+		maxContext = m.GetMaxContextSize()
+		if maxContext > 0 {
+			contextPercent = float64(contextSize) / float64(maxContext) * 100
+		}
+	}
+
+	// Build placeholder map
+	placeholders := map[string]string{
+		"{app}":             tmuxaiColor.Sprint("TmuxAI"),
+		"{model}":           modelColor.Sprint(m.getModelLabel()),
+		"{state}":           stateColor.Sprint(stateSymbol),
+		"{context}":         contextColor.Sprint(formatCompactNumber(contextSize)),
+		"{max_context}":     maxContextColor.Sprint(formatCompactNumber(maxContext)),
+		"{context_percent}": percentColor.Sprint(fmt.Sprintf("%.0f%%", contextPercent)),
+	}
+
+	// Replace placeholders
+	result := template
+	for placeholder, value := range placeholders {
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+
+	return result
 }
 
 func (ai *AIResponse) String() string {
@@ -342,4 +456,3 @@ func (m *Manager) ensureMcpToolDefs() string {
 	}
 	return m.McpToolDefCached
 }
-

--- a/internal/manager_test.go
+++ b/internal/manager_test.go
@@ -1,0 +1,240 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/alvinunreal/tmuxai/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatCompactNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"zero", 0, "0"},
+		{"small number", 500, "500"},
+		{"exact thousand", 1000, "1k"},
+		{"thousands", 37000, "37k"},
+		{"large thousands", 999999, "999k"},
+		{"million", 1000000, "1.0m"},
+		{"millions", 2500000, "2.5m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatCompactNumber(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetCustomPromptTemplate(t *testing.T) {
+	tests := []struct {
+		name           string
+		configPrompt   string
+		sessionPrompt  interface{}
+		hasOverride    bool
+		expectedResult string
+	}{
+		{
+			name:           "no custom prompt configured",
+			configPrompt:   "",
+			hasOverride:    false,
+			expectedResult: "",
+		},
+		{
+			name:           "custom prompt from config",
+			configPrompt:   "{app} » ",
+			hasOverride:    false,
+			expectedResult: "{app} » ",
+		},
+		{
+			name:           "session override takes precedence",
+			configPrompt:   "{app} » ",
+			sessionPrompt:  "✨ ",
+			hasOverride:    true,
+			expectedResult: "✨ ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &Manager{
+				Config: &config.Config{
+					Prompts: config.PromptsConfig{
+						Prompt: tt.configPrompt,
+					},
+				},
+				SessionOverrides: make(map[string]interface{}),
+				LoadedKBs:        make(map[string]string),
+			}
+
+			if tt.hasOverride {
+				manager.SessionOverrides["prompts.prompt"] = tt.sessionPrompt
+			}
+
+			result := manager.getCustomPromptTemplate()
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestGetPromptDefaultBehavior(t *testing.T) {
+	// Test default prompt without custom template
+	manager := &Manager{
+		Config: &config.Config{
+			DefaultModel: "test-model",
+			Models: map[string]config.ModelConfig{
+				"test-model": {Provider: "openai", Model: "gpt-4"},
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+		Status:           "running",
+	}
+
+	prompt := manager.GetPrompt()
+	// Should contain TmuxAI
+	assert.Contains(t, prompt, "TmuxAI")
+	// Should contain the arrow
+	assert.Contains(t, prompt, "»")
+}
+
+func TestGetPromptWithCustomTemplate(t *testing.T) {
+	manager := &Manager{
+		Config: &config.Config{
+			DefaultModel:   "test-model",
+			MaxContextSize: 100000,
+			Prompts: config.PromptsConfig{
+				Prompt: "{app} ({context}/{max_context}) » ",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+		Messages:         []ChatMessage{},
+		Status:           "",
+	}
+
+	prompt := manager.GetPrompt()
+	// Should contain TmuxAI (colored)
+	assert.Contains(t, prompt, "TmuxAI")
+	// Should contain context info (0/100k)
+	assert.Contains(t, prompt, "0")
+	assert.Contains(t, prompt, "100k")
+	// Should contain arrow
+	assert.Contains(t, prompt, "»")
+}
+
+func TestGetPromptWithAllPlaceholders(t *testing.T) {
+	manager := &Manager{
+		Config: &config.Config{
+			DefaultModel:   "my-model",
+			MaxContextSize: 200000,
+			Prompts: config.PromptsConfig{
+				Prompt: "{app} {model} {state} {context} {max_context} {context_percent}",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+		Messages:         []ChatMessage{},
+		Status:           "running",
+		WatchMode:        false,
+	}
+
+	prompt := manager.GetPrompt()
+	// All placeholders should be replaced (not present in output)
+	assert.NotContains(t, prompt, "{app}")
+	assert.NotContains(t, prompt, "{model}")
+	assert.NotContains(t, prompt, "{state}")
+	assert.NotContains(t, prompt, "{context}")
+	assert.NotContains(t, prompt, "{max_context}")
+	assert.NotContains(t, prompt, "{context_percent}")
+	// Should contain the values
+	assert.Contains(t, prompt, "TmuxAI")
+	assert.Contains(t, prompt, "my-model")
+	assert.Contains(t, prompt, "▶") // running state
+	assert.Contains(t, prompt, "200k")
+}
+
+func TestGetPromptWithUnknownPlaceholders(t *testing.T) {
+	// Unknown placeholders should be kept as-is (benign behavior)
+	manager := &Manager{
+		Config: &config.Config{
+			Prompts: config.PromptsConfig{
+				Prompt: "{app} {unknown} {foo}",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+	}
+
+	prompt := manager.GetPrompt()
+	// Known placeholder replaced
+	assert.Contains(t, prompt, "TmuxAI")
+	// Unknown placeholders kept literal
+	assert.Contains(t, prompt, "{unknown}")
+	assert.Contains(t, prompt, "{foo}")
+}
+
+func TestGetPromptWithCompactTemplate(t *testing.T) {
+	// Test a compact prompt like "✨ "
+	manager := &Manager{
+		Config: &config.Config{
+			Prompts: config.PromptsConfig{
+				Prompt: "✨ ",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+	}
+
+	prompt := manager.GetPrompt()
+	// Custom templates are the full prompt string.
+	assert.Equal(t, "✨ ", prompt)
+	assert.Contains(t, prompt, "✨")
+	assert.NotContains(t, prompt, "»")
+}
+
+func TestGetPromptWatchModeState(t *testing.T) {
+	manager := &Manager{
+		Config: &config.Config{
+			Prompts: config.PromptsConfig{
+				Prompt: "{app} {state}",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+		Status:           "running",
+		WatchMode:        true,
+	}
+
+	prompt := manager.GetPrompt()
+	// Watch mode should show ∞ symbol regardless of status
+	assert.Contains(t, prompt, "∞")
+	assert.NotContains(t, prompt, "▶")
+}
+
+func TestGetPromptContextCalculation(t *testing.T) {
+	manager := &Manager{
+		Config: &config.Config{
+			MaxContextSize: 100000,
+			Prompts: config.PromptsConfig{
+				Prompt: "{context}/{max_context} ({context_percent})",
+			},
+		},
+		SessionOverrides: make(map[string]interface{}),
+		LoadedKBs:        make(map[string]string),
+		Messages: []ChatMessage{
+			{Content: "Hello world this is a test message"},
+			{Content: "Another message here"},
+		},
+	}
+
+	prompt := manager.GetPrompt()
+	// Should contain formatted context info
+	assert.Contains(t, prompt, "100k")
+	// Should contain percentage (should be very small %)
+	assert.Contains(t, prompt, "%")
+}


### PR DESCRIPTION
## Summary
- Add a `prompts.prompt` template for customizing the interactive prompt.
- Support prompt placeholders for app name, model, state, context usage, max context, and context percent.
- Document prompt examples and cover template rendering with tests.

## Validation
- go test ./...