### PR TITLE
feat: add configurable status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [Core Commands](#core-commands)
 - [Command-Line Usage](#command-line-usage)
 - [Configuration](#configuration)
+  - [Status Line Customization](#status-line-customization)
   - [Environment Variables](#environment-variables)
   - [Session-Specific Configuration](#session-specific-configuration)
 - [Contributing](#contributing)
@@ -893,6 +894,49 @@ The configuration can be managed through a YAML file, environment variables, or 
 
 TmuxAI looks for its configuration file at `~/.config/tmuxai/config.yaml`.
 For a sample configuration file, see [config.example.yaml](https://github.com/alvinunreal/tmuxai/blob/main/config.example.yaml).
+
+### Status Line Customization
+
+By default, TmuxAI uses its built-in interactive prompt:
+
+```text
+TmuxAI »
+```
+
+You can customize that prompt/status prefix with `status_line`:
+
+```yaml
+status_line: "{app} ({context}) - {model} >> "
+```
+
+Available placeholders:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{app}` | `TmuxAI` |
+| `{context}` | Approximate used/max context tokens, e.g. `37k/256k` |
+| `{context_used}` | Approximate used context tokens |
+| `{context_max}` | Configured max context tokens |
+| `{model}` | Current model configuration name |
+| `{state}` | Current state symbol, if active |
+| `{state_badge}` | Current state symbol in brackets, if active |
+| `{model_changed}` | Current model badge when it differs from the configured default; requires the `models:` config section |
+
+Examples:
+
+```yaml
+# Compact prompt with context usage
+status_line: "✨ ({context}) >> "
+
+# Include model information
+status_line: "{app} ({context}) - {model} >> "
+```
+
+You can also try a status line for the current session only:
+
+```bash
+TmuxAI » /config set status_line ✨ ({context}) >>
+```
 
 ### tmux pane split configuration
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,14 @@ yolo: false
 # Maximum context size in tokens, reaching 80% triggers squashing
 max_context_size: 100000
 
+# Interactive prompt/status line shown before input and status messages.
+# Empty uses the built-in prompt. Available placeholders:
+# {app}, {context}, {context_used}, {context_max}, {model}, {state}, {state_badge}, {model_changed}
+# Examples:
+#   "{app} ({context}) - {model} >> "
+#   "✨ ({context}) >> "
+status_line: ""
+
 # Maximum number of lines to capture during each message
 max_capture_lines: 200
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,7 @@ max_context_size: 100000
 # Interactive prompt/status line shown before input and status messages.
 # Empty uses the built-in prompt. Available placeholders:
 # {app}, {context}, {context_used}, {context_max}, {model}, {state}, {state_badge}, {model_changed}
+# Note: {model_changed} only produces output when using the models: config section.
 # Examples:
 #   "{app} ({context}) - {model} >> "
 #   "✨ ({context}) >> "

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Yolo                  bool                   `mapstructure:"yolo"`
 	MaxCaptureLines       int                    `mapstructure:"max_capture_lines"`
 	MaxContextSize        int                    `mapstructure:"max_context_size"`
+	StatusLine            string                 `mapstructure:"status_line"`
 	WaitInterval          int                    `mapstructure:"wait_interval"`
 	SendKeysConfirm       bool                   `mapstructure:"send_keys_confirm"`
 	PasteMultilineConfirm bool                   `mapstructure:"paste_multiline_confirm"`
@@ -149,6 +150,7 @@ func DefaultConfig() *Config {
 		Yolo:                  false,
 		MaxCaptureLines:       200,
 		MaxContextSize:        100000,
+		StatusLine:            ``,
 		WaitInterval:          5,
 		SendKeysConfirm:       true,
 		PasteMultilineConfirm: true,

--- a/internal/config_helpers.go
+++ b/internal/config_helpers.go
@@ -26,6 +26,7 @@ var AllowedConfigKeys = []string{
 	"azure_openai.api_base",
 	"azure_openai.api_version",
 	"default_model",
+	"status_line",
 }
 
 // GetMaxCaptureLines returns the max capture lines value with session override if present
@@ -101,6 +102,15 @@ func (m *Manager) GetYolo() bool {
 		}
 	}
 	return m.Config.Yolo
+}
+
+func (m *Manager) GetPromptTemplate() string {
+	if override, exists := m.SessionOverrides["status_line"]; exists {
+		if val, ok := override.(string); ok {
+			return val
+		}
+	}
+	return m.Config.StatusLine
 }
 
 func (m *Manager) GetOpenRouterModel() string {

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -166,6 +166,11 @@ func (m *Manager) GetConfig() *config.Config {
 
 // getPrompt returns the prompt string with color
 func (m *Manager) GetPrompt() string {
+	template := m.GetPromptTemplate()
+	if template != "" {
+		return m.renderPromptTemplate(template)
+	}
+
 	tmuxaiColor := color.New(color.FgGreen, color.Bold)
 	arrowColor := color.New(color.FgYellow, color.Bold)
 	stateColor := color.New(color.FgMagenta, color.Bold)
@@ -209,6 +214,120 @@ func (m *Manager) GetPrompt() string {
 	}
 	prompt += arrowColor.Sprint(" » ")
 	return prompt
+}
+
+func (m *Manager) renderPromptTemplate(template string) string {
+	tmuxaiColor := color.New(color.FgGreen, color.Bold)
+	stateColor := color.New(color.FgMagenta, color.Bold)
+	modelColor := color.New(color.FgCyan, color.Bold)
+
+	replacements := map[string]string{
+		"{app}": tmuxaiColor.Sprint("TmuxAI"),
+	}
+
+	if promptTemplateHasAny(template, "{context}", "{context_used}", "{context_max}") {
+		contextUsed, contextMax := m.getPromptContextTokens()
+		replacements["{context}"] = fmt.Sprintf("%s/%s", formatPromptTokenCount(contextUsed), formatPromptTokenCount(contextMax))
+		replacements["{context_used}"] = formatPromptTokenCount(contextUsed)
+		replacements["{context_max}"] = formatPromptTokenCount(contextMax)
+	}
+
+	if promptTemplateHasAny(template, "{model}") {
+		replacements["{model}"] = modelColor.Sprint(m.getPromptModelName())
+	}
+
+	if promptTemplateHasAny(template, "{state}", "{state_badge}") {
+		stateSymbol := m.getPromptStateSymbol()
+		replacements["{state}"] = stateColor.Sprint(stateSymbol)
+		replacements["{state_badge}"] = ""
+		if stateSymbol != "" {
+			replacements["{state_badge}"] = stateColor.Sprint("[" + stateSymbol + "]")
+		}
+	}
+
+	if strings.Contains(template, "{model_changed}") {
+		replacements["{model_changed}"] = ""
+		if changedModel := m.getPromptChangedModelName(); changedModel != "" {
+			replacements["{model_changed}"] = modelColor.Sprint("[" + changedModel + "]")
+		}
+	}
+
+	prompt := template
+	for placeholder, value := range replacements {
+		prompt = strings.ReplaceAll(prompt, placeholder, value)
+	}
+	return prompt
+}
+
+func promptTemplateHasAny(template string, placeholders ...string) bool {
+	for _, placeholder := range placeholders {
+		if strings.Contains(template, placeholder) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) getPromptStateSymbol() string {
+	stateSymbol := ""
+	switch m.Status {
+	case "running":
+		stateSymbol = "▶"
+	case "waiting":
+		stateSymbol = "?"
+	case "done":
+		stateSymbol = "✓"
+	}
+	if m.WatchMode {
+		stateSymbol = "∞"
+	}
+	return stateSymbol
+}
+
+func (m *Manager) getPromptContextTokens() (int, int) {
+	totalTokens := 0
+	for _, msg := range m.Messages {
+		totalTokens += system.EstimateTokenCount(msg.Content)
+	}
+	return totalTokens, m.GetMaxContextSize()
+}
+
+func (m *Manager) getPromptModelName() string {
+	availableModels := m.GetAvailableModels()
+	if len(availableModels) > 0 {
+		modelName := m.GetModelsDefault()
+		if modelName == "" {
+			modelName = availableModels[0]
+		}
+		return modelName
+	}
+
+	currentModelConfig, _ := m.GetCurrentModelConfig()
+	return currentModelConfig.Model
+}
+
+func (m *Manager) getPromptChangedModelName() string {
+	currentModel := m.GetModelsDefault()
+	availableModels := m.GetAvailableModels()
+	if len(availableModels) == 0 {
+		return ""
+	}
+
+	expectedModel := m.Config.DefaultModel
+	if expectedModel == "" {
+		expectedModel = availableModels[0]
+	}
+	if currentModel != "" && currentModel != expectedModel {
+		return currentModel
+	}
+	return ""
+}
+
+func formatPromptTokenCount(tokens int) string {
+	if tokens >= 1000 {
+		return fmt.Sprintf("%dk", (tokens+500)/1000)
+	}
+	return fmt.Sprintf("%d", tokens)
 }
 
 func (ai *AIResponse) String() string {
@@ -342,4 +461,3 @@ func (m *Manager) ensureMcpToolDefs() string {
 	}
 	return m.McpToolDefCached
 }
-

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -240,10 +240,12 @@ func (m *Manager) renderPromptTemplate(template string) string {
 
 	if promptTemplateHasAny(template, "{state}", "{state_badge}") {
 		stateSymbol := m.getPromptStateSymbol()
-		replacements["{state}"] = stateColor.Sprint(stateSymbol)
-		replacements["{state_badge}"] = ""
 		if stateSymbol != "" {
+			replacements["{state}"] = stateColor.Sprint(stateSymbol)
 			replacements["{state_badge}"] = stateColor.Sprint("[" + stateSymbol + "]")
+		} else {
+			replacements["{state}"] = ""
+			replacements["{state_badge}"] = ""
 		}
 	}
 

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -235,7 +235,12 @@ func (m *Manager) renderPromptTemplate(template string) string {
 	}
 
 	if promptTemplateHasAny(template, "{model}") {
-		replacements["{model}"] = modelColor.Sprint(m.getPromptModelName())
+		modelName := m.getPromptModelName()
+		if modelName != "" {
+			replacements["{model}"] = modelColor.Sprint(modelName)
+		} else {
+			replacements["{model}"] = ""
+		}
 	}
 
 	if promptTemplateHasAny(template, "{state}", "{state_badge}") {

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -221,8 +221,10 @@ func (m *Manager) renderPromptTemplate(template string) string {
 	stateColor := color.New(color.FgMagenta, color.Bold)
 	modelColor := color.New(color.FgCyan, color.Bold)
 
-	replacements := map[string]string{
-		"{app}": tmuxaiColor.Sprint("TmuxAI"),
+	replacements := map[string]string{}
+
+	if strings.Contains(template, "{app}") {
+		replacements["{app}"] = tmuxaiColor.Sprint("TmuxAI")
 	}
 
 	if promptTemplateHasAny(template, "{context}", "{context_used}", "{context_max}") {
@@ -295,11 +297,7 @@ func (m *Manager) getPromptContextTokens() (int, int) {
 func (m *Manager) getPromptModelName() string {
 	availableModels := m.GetAvailableModels()
 	if len(availableModels) > 0 {
-		modelName := m.GetModelsDefault()
-		if modelName == "" {
-			modelName = availableModels[0]
-		}
-		return modelName
+		return m.GetModelsDefault()
 	}
 
 	currentModelConfig, _ := m.GetCurrentModelConfig()

--- a/internal/prompts_test.go
+++ b/internal/prompts_test.go
@@ -176,6 +176,17 @@ func TestPromptEmptyStateHasNoAnsiCodes(t *testing.T) {
 	assert.False(t, regexp.MustCompile(`\x1b\[[0-9;]*m`).MatchString(prompt))
 }
 
+func TestPromptEmptyModelHasNoAnsiCodes(t *testing.T) {
+	cfg := &config.Config{
+		StatusLine:     "{model}",
+		MaxContextSize: 100000,
+	}
+	m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}}
+	prompt := m.GetPrompt()
+	assert.Empty(t, prompt)
+	assert.False(t, regexp.MustCompile(`\x1b\[[0-9;]*m`).MatchString(prompt))
+}
+
 func TestPromptWithLargeContext(t *testing.T) {
 	largeContent := strings.Repeat("Hello world this is a test message with many tokens. ", 500)
 	cfg := &config.Config{

--- a/internal/prompts_test.go
+++ b/internal/prompts_test.go
@@ -1,0 +1,178 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alvinunreal/tmuxai/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPromptLegacyWhenEmpty(t *testing.T) {
+	cfg := &config.Config{
+		DefaultModel: "gpt4",
+		Models: map[string]config.ModelConfig{
+			"gpt4":   {Provider: "openai", Model: "gpt-4", APIKey: "sk"},
+			"claude": {Provider: "openrouter", Model: "claude", APIKey: "sk"},
+		},
+	}
+
+	t.Run("basic legacy prompt", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Messages: []ChatMessage{}}
+		m.SetModelsDefault("gpt4")
+		prompt := m.GetPrompt()
+		assert.Contains(t, prompt, "TmuxAI")
+		assert.Contains(t, prompt, "»")
+		assert.NotContains(t, prompt, "[gpt4]")
+	})
+
+	t.Run("status symbols", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Messages: []ChatMessage{}}
+		m.SetModelsDefault("gpt4")
+
+		m.Status = "running"
+		assert.Contains(t, m.GetPrompt(), "▶")
+
+		m.Status = "waiting"
+		assert.Contains(t, m.GetPrompt(), "?")
+
+		m.Status = "done"
+		assert.Contains(t, m.GetPrompt(), "✓")
+	})
+
+	t.Run("watch mode overrides status", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Status: "running", WatchMode: true}
+		m.SetModelsDefault("gpt4")
+		prompt := m.GetPrompt()
+		assert.Contains(t, prompt, "∞")
+		assert.NotContains(t, prompt, "▶")
+	})
+
+	t.Run("changed model shown when different", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Messages: []ChatMessage{}}
+		m.SetModelsDefault("claude") // Different from config default "gpt4"
+		prompt := m.GetPrompt()
+		assert.Contains(t, prompt, "[claude]")
+	})
+}
+
+func TestGetPromptCustomTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		status   string
+		contains []string
+	}{
+		{
+			name:     "app placeholder",
+			template: "{app}> ",
+			contains: []string{"TmuxAI", ">"},
+		},
+		{
+			name:     "state badge with status",
+			template: "{app} {state_badge}$ ",
+			status:   "running",
+			contains: []string{"TmuxAI", "[▶]", "$"},
+		},
+		{
+			name:     "model placeholder",
+			template: "[{model}] {app}> ",
+			contains: []string{"[gpt4]", "TmuxAI", ">"},
+		},
+		{
+			name:     "context placeholder",
+			template: "{app} {context}> ",
+			contains: []string{"TmuxAI", "/", ">"},
+		},
+	}
+
+	cfg := &config.Config{
+		DefaultModel:   "gpt4",
+		Models:         map[string]config.ModelConfig{"gpt4": {Provider: "openai", Model: "gpt-4", APIKey: "sk"}},
+		MaxContextSize: 100000,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.StatusLine = tt.template
+			m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Messages: []ChatMessage{{Content: "test"}}, Status: tt.status}
+			m.SetModelsDefault("gpt4")
+			prompt := m.GetPrompt()
+			for _, s := range tt.contains {
+				assert.Contains(t, prompt, s)
+			}
+		})
+	}
+}
+
+func TestGetPromptSessionOverride(t *testing.T) {
+	cfg := &config.Config{
+		StatusLine:   "{app}> ",
+		DefaultModel: "gpt4",
+		Models:       map[string]config.ModelConfig{"gpt4": {Provider: "openai", Model: "gpt-4", APIKey: "sk"}},
+	}
+
+	t.Run("session override takes precedence", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{"status_line": "[{model}] » "}, LoadedKBs: map[string]string{}}
+		m.SetModelsDefault("gpt4")
+		prompt := m.GetPrompt()
+		assert.Contains(t, prompt, "[gpt4]")
+		assert.Contains(t, prompt, "»")
+		assert.NotContains(t, prompt, "TmuxAI>")
+	})
+
+	t.Run("empty session override falls back to legacy", func(t *testing.T) {
+		m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{"status_line": ""}, LoadedKBs: map[string]string{}, Status: "running"}
+		m.SetModelsDefault("gpt4")
+		prompt := m.GetPrompt()
+		assert.Contains(t, prompt, "TmuxAI")
+		assert.Contains(t, prompt, "▶")
+	})
+}
+
+func TestFormatPromptTokenCount(t *testing.T) {
+	tests := []struct {
+		tokens   int
+		expected string
+	}{
+		{999, "999"},
+		{1000, "1k"},
+		{1500, "2k"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatPromptTokenCount(tt.tokens)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPromptUnknownPlaceholdersPreserved(t *testing.T) {
+	cfg := &config.Config{
+		StatusLine:   "{app} {unknown} » ",
+		DefaultModel: "gpt4",
+		Models:       map[string]config.ModelConfig{"gpt4": {Provider: "openai", Model: "gpt-4", APIKey: "sk"}},
+	}
+	m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}}
+	m.SetModelsDefault("gpt4")
+	prompt := m.GetPrompt()
+	assert.Contains(t, prompt, "TmuxAI")
+	assert.Contains(t, prompt, "{unknown}")
+}
+
+func TestPromptWithLargeContext(t *testing.T) {
+	largeContent := strings.Repeat("Hello world this is a test message with many tokens. ", 500)
+	cfg := &config.Config{
+		StatusLine:     "{app} {context} » ",
+		DefaultModel:   "gpt4",
+		Models:         map[string]config.ModelConfig{"gpt4": {Provider: "openai", Model: "gpt-4", APIKey: "sk"}},
+		MaxContextSize: 100000,
+	}
+	m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}, Messages: []ChatMessage{{Content: largeContent}}}
+	m.SetModelsDefault("gpt4")
+	prompt := m.GetPrompt()
+	assert.Contains(t, prompt, "TmuxAI")
+	assert.Contains(t, prompt, "/") // Shows used/max format
+	assert.Contains(t, prompt, "»")
+}

--- a/internal/prompts_test.go
+++ b/internal/prompts_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -159,6 +160,20 @@ func TestPromptUnknownPlaceholdersPreserved(t *testing.T) {
 	prompt := m.GetPrompt()
 	assert.Contains(t, prompt, "TmuxAI")
 	assert.Contains(t, prompt, "{unknown}")
+}
+
+func TestPromptEmptyStateHasNoAnsiCodes(t *testing.T) {
+	cfg := &config.Config{
+		StatusLine:     "{state}{state_badge}",
+		DefaultModel:   "gpt4",
+		Models:         map[string]config.ModelConfig{"gpt4": {Provider: "openai", Model: "gpt-4", APIKey: "sk"}},
+		MaxContextSize: 100000,
+	}
+	m := &Manager{Config: cfg, SessionOverrides: map[string]interface{}{}, LoadedKBs: map[string]string{}}
+	m.SetModelsDefault("gpt4")
+	prompt := m.GetPrompt()
+	assert.Empty(t, prompt)
+	assert.False(t, regexp.MustCompile(`\x1b\[[0-9;]*m`).MatchString(prompt))
 }
 
 func TestPromptWithLargeContext(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add root-level `status_line` config for customizing the interactive prompt/status prefix.
- Support context, model, app, state, and changed-model placeholders while preserving the built-in prompt by default.
- Document examples and add focused prompt rendering tests.

## Validation
- `go test ./...`