### PR TITLE
Add Requesty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ TmuxAI reads its configuration from `~/.config/tmuxai/config.yaml`. To get runni
    ```yaml
    models:
      primary:
-       provider: openrouter  # openrouter, openai or azure
+       provider: openrouter  # openrouter, requesty, openai or azure
        model: anthropic/claude-haiku-4.5
        api_key: sk-your-api-key
    ```
@@ -595,7 +595,14 @@ models:
   smart:
     provider: "openrouter"
     model: "google/gemini-2.5-prod"
-    api_key: "sk-or-your-openrouter-key"
+    api_key: "sk-or-...-key"
+
+  # Requesty (OpenAI-compatible router, defaults to https://router.requesty.ai/v1)
+  # Get a key at https://app.requesty.ai/api-keys ; browse models at https://app.requesty.ai/router/list
+  requesty:
+    provider: "requesty"
+    model: "openai/gpt-4o-mini"
+    api_key: "${REQUESTY_API_KEY}"
 
   # You can use any chat completion compatible endpoint as base_url
   anthropic:
@@ -640,6 +647,7 @@ models:
 **Supported Providers:**
 - `openai` - OpenAI Responses API (GPT-4, GPT-5, etc.)
 - `openrouter` - Universal Chat Completion API, defaults to openrouter base url
+- `requesty` - [Requesty](https://requesty.ai) router (OpenAI-compatible Chat Completion API), defaults to `https://router.requesty.ai/v1`. Browse models at [app.requesty.ai/router/list](https://app.requesty.ai/router/list)
 - `azure` - Azure Chat Completions API
 - `gemini` - Google Gemini API (direct access via go-genai SDK)
 - `github-copilot` - GitHub Copilot (via official copilot-sdk/go — see setup below)
@@ -995,6 +1003,7 @@ export TMUXAI_MAX_CONTEXT_SIZE=150000
 export TMUXAI_OPENAI_API_KEY="your-openai-api-key-here"
 export TMUXAI_OPENAI_MODEL="gpt-4"
 export TMUXAI_OPENROUTER_API_KEY="your-openrouter-api-key-here"
+export TMUXAI_REQUESTY_API_KEY="your-requesty-api-key-here"
 ```
 
 You can also use environment variables directly within your configuration file values. The application will automatically expand these variables when loading the configuration:
@@ -1008,6 +1017,10 @@ openai:
 openrouter:
   api_key: "${OPENROUTER_API_KEY}"
   base_url: "${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}"
+
+requesty:
+  api_key: "${REQUESTY_API_KEY}"
+  base_url: "${REQUESTY_BASE_URL:-https://router.requesty.ai/v1}"
 ```
 
 ### Session-Specific Configuration

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,7 +46,14 @@ models:
   smart:
     provider: "openrouter"
     model: "google/gemini-2.5-prod"
-    api_key: "sk-or-your-openrouter-key"
+    api_key: "sk-or-...-key"
+
+  # Requesty (OpenAI-compatible router, defaults to https://router.requesty.ai/v1)
+  # Get a key at https://app.requesty.ai/api-keys ; browse models at https://app.requesty.ai/router/list
+  requesty:
+    provider: "requesty"
+    model: "openai/gpt-4o-mini"
+    api_key: "${REQUESTY_API_KEY}"
 
   # You can use any chat completion compatible endpoint as base_url
   anthropic:

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	BlacklistPatterns     []string               `mapstructure:"blacklist_patterns"`
 	Tmux                  TmuxConfig             `mapstructure:"tmux"`
 	OpenRouter            OpenRouterConfig       `mapstructure:"openrouter"`
+	Requesty              RequestyConfig         `mapstructure:"requesty"`
 	OpenAI                OpenAIConfig           `mapstructure:"openai"`
 	AzureOpenAI           AzureOpenAIConfig      `mapstructure:"azure_openai"`
 	DefaultModel          string                 `mapstructure:"default_model"`
@@ -37,6 +38,13 @@ type Config struct {
 
 // OpenRouterConfig holds OpenRouter API configuration
 type OpenRouterConfig struct {
+	APIKey  string `mapstructure:"api_key"`
+	Model   string `mapstructure:"model"`
+	BaseURL string `mapstructure:"base_url"`
+}
+
+// RequestyConfig holds Requesty API configuration
+type RequestyConfig struct {
 	APIKey  string `mapstructure:"api_key"`
 	Model   string `mapstructure:"model"`
 	BaseURL string `mapstructure:"base_url"`
@@ -163,6 +171,10 @@ func DefaultConfig() *Config {
 		OpenRouter: OpenRouterConfig{
 			BaseURL: "https://openrouter.ai/api/v1",
 			Model:   "google/gemini-2.5-flash-preview",
+		},
+		Requesty: RequestyConfig{
+			BaseURL: "https://router.requesty.ai/v1",
+			Model:   "openai/gpt-4o-mini",
 		},
 		OpenAI: OpenAIConfig{
 			BaseURL: "https://api.openai.com/v1",

--- a/internal/ai_client.go
+++ b/internal/ai_client.go
@@ -264,6 +264,8 @@ func (c *AiClient) determineAPIType(model string) string {
 				return "azure"
 			case "openrouter":
 				return "openrouter"
+			case "requesty":
+				return "requesty"
 			case "gemini":
 				return "gemini"
 			case "github-copilot":
@@ -330,6 +332,8 @@ func (c *AiClient) GetResponseFromChatMessages(ctx context.Context, chatMessages
 		response, err = c.ChatCompletion(ctx, aiMessages, model)
 	case "openrouter":
 		response, err = c.ChatCompletion(ctx, aiMessages, model)
+	case "requesty":
+		response, err = c.ChatCompletion(ctx, aiMessages, model)
 	case "github-copilot":
 		response, err = c.CopilotGenerateContent(ctx, aiMessages, model)
 	case "gemini":
@@ -392,6 +396,10 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 			provider = "openrouter"
 			apiKey = c.config.OpenRouter.APIKey
 			baseURL = c.config.OpenRouter.BaseURL
+		} else if c.config.Requesty.APIKey != "" {
+			provider = "requesty"
+			apiKey = c.config.Requesty.APIKey
+			baseURL = c.config.Requesty.BaseURL
 		}
 	}
 
@@ -413,7 +421,11 @@ func (c *AiClient) ChatCompletion(ctx context.Context, messages []Message, model
 	} else {
 		// default OpenRouter/OpenAI compatible endpoint
 		if baseURL == "" {
-			baseURL = c.config.OpenRouter.BaseURL
+			if provider == "requesty" {
+				baseURL = c.config.Requesty.BaseURL
+			} else {
+				baseURL = c.config.OpenRouter.BaseURL
+			}
 		}
 		base := strings.TrimSuffix(baseURL, "/")
 		url = base + "/chat/completions"

--- a/internal/config_helpers.go
+++ b/internal/config_helpers.go
@@ -18,6 +18,7 @@ var AllowedConfigKeys = []string{
 	"exec_confirm",
 	"yolo",
 	"openrouter.model",
+	"requesty.model",
 	"openai.api_key",
 	"openai.model",
 	"openai.base_url",
@@ -120,6 +121,16 @@ func (m *Manager) GetOpenRouterModel() string {
 		}
 	}
 	return m.Config.OpenRouter.Model
+}
+
+// GetRequestyModel returns the Requesty model value with session override if present
+func (m *Manager) GetRequestyModel() string {
+	if override, exists := m.SessionOverrides["requesty.model"]; exists {
+		if val, ok := override.(string); ok {
+			return val
+		}
+	}
+	return m.Config.Requesty.Model
 }
 
 // GetOpenAIModel returns the OpenAI model value with session override if present
@@ -260,7 +271,7 @@ func (m *Manager) hasValidAIConfiguration() bool {
 	}
 
 	// Fall back to legacy configuration
-	return m.Config.OpenRouter.APIKey != "" || m.Config.OpenAI.APIKey != "" || m.Config.AzureOpenAI.APIKey != ""
+	return m.Config.OpenRouter.APIKey != "" || m.Config.Requesty.APIKey != "" || m.Config.OpenAI.APIKey != "" || m.Config.AzureOpenAI.APIKey != ""
 }
 
 // getLegacyModelConfig converts the legacy provider configuration to a ModelConfig

--- a/internal/config_helpers.go
+++ b/internal/config_helpers.go
@@ -297,6 +297,15 @@ func (m *Manager) getLegacyModelConfig() config.ModelConfig {
 		}
 	}
 
+	if m.Config.Requesty.APIKey != "" && m.Config.OpenRouter.APIKey == "" {
+		return config.ModelConfig{
+			Provider: "requesty",
+			Model:    m.GetRequestyModel(),
+			APIKey:   m.Config.Requesty.APIKey,
+			BaseURL:  m.Config.Requesty.BaseURL,
+		}
+	}
+
 	return config.ModelConfig{
 		Provider: "openrouter",
 		Model:    m.GetOpenRouterModel(),
@@ -330,6 +339,11 @@ func (m *Manager) GetModel() string {
 			}
 			// Default deployment for Azure if not specified
 			return "gpt-4o"
+		}
+
+		// If only Requesty is configured, use the Requesty model
+		if m.Config.Requesty.APIKey != "" && m.Config.OpenRouter.APIKey == "" {
+			return m.GetRequestyModel()
 		}
 
 		// Default to OpenRouter

--- a/internal/model_config_test.go
+++ b/internal/model_config_test.go
@@ -234,11 +234,23 @@ func TestGetModel(t *testing.T) {
 				DefaultModel: "",
 				Models:       map[string]config.ModelConfig{},
 				OpenRouter: config.OpenRouterConfig{
-					APIKey: "sk-or-test-key",
+					APIKey: "***",
 					Model:  "gemini-flash",
 				},
 			},
 			expectedModel: "gemini-flash",
+		},
+		{
+			name: "fallback to legacy requesty when only requesty configured",
+			config: &config.Config{
+				DefaultModel: "",
+				Models:       map[string]config.ModelConfig{},
+				Requesty: config.RequestyConfig{
+					APIKey: "***",
+					Model:  "openai/gpt-4o-mini",
+				},
+			},
+			expectedModel: "openai/gpt-4o-mini",
 		},
 	}
 


### PR DESCRIPTION
## Add Requesty provider

This adds [Requesty](https://requesty.ai) as a provider, alongside the existing OpenRouter / OpenAI / Azure options.

Requesty is an OpenAI-compatible model gateway that uses the same `provider/model` identifier format as OpenRouter, so it is implemented by mirroring the existing OpenRouter provider (only the base URL and env var differ).

### Changes
- `config/config.go` — `RequestyConfig` struct + `Requesty` field, default `base_url` `https://router.requesty.ai/v1`, key from `REQUESTY_API_KEY`, mirroring `OpenRouterConfig`.
- `internal/ai_client.go` — requesty entry in the provider switch + key-based provider detection, mirroring openrouter.
- `internal/config_helpers.go` — requesty config handling alongside the others.
- `README.md`, `config.example.yaml` — document Requesty alongside OpenRouter (key at https://app.requesty.ai/api-keys, models at https://app.requesty.ai/router/list).

### Testing
- `go build ./...` clean, `go vet ./...` clean, `gofmt -l` empty, `go test ./...` all pass.
- Live endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` -> HTTP 200, real completion.

### Disclosure
I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust naming/placement or close it if it's not a fit.
